### PR TITLE
Bump content tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@babel/eslint-parser": "7.23.10",
     "@glimmer/syntax": "^0.92.0",
-    "content-tag": "^1.2.2",
+    "content-tag": "^2.0.1",
     "eslint-scope": "^7.2.2",
     "html-tags": "^3.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^0.92.0
         version: 0.92.0
       content-tag:
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^2.0.1
+        version: 2.0.1
       eslint-scope:
         specifier: ^7.2.2
         version: 7.2.2
@@ -4143,8 +4143,8 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /content-tag@1.2.2:
-    resolution: {integrity: sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==}
+  /content-tag@2.0.1:
+    resolution: {integrity: sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==}
     dev: false
 
   /convert-source-map@2.0.0:


### PR DESCRIPTION
Updates `content-tag` to v2.

The breaking change in v2 is a change in second argument to method `.parse()` which is not used by `ember-cli` so it's save update.

Changelog https://github.com/embroider-build/content-tag/releases/tag/v2.0.0-content-tag