### PR TITLE
Add missing parser metadata

### DIFF
--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -20,6 +20,11 @@ const { transformForLint, preprocessGlimmerTemplates, convertAst } = require('./
  * @type {import('eslint').ParserModule}
  */
 module.exports = {
+  meta: {
+    name: 'ember-eslint-parser',
+    version: '*',
+  },
+
   parseForESLint(code, options) {
     patchTs();
     registerParsedFile(options.filePath);


### PR DESCRIPTION
v9 docs: https://eslint.org/docs/latest/extend/custom-parsers#meta-data-in-custom-parsers.

v8 docs: https://eslint.org/docs/v8.x/extend/custom-parsers#meta-data-in-custom-parsers (should be retrocompatible).

Not sure the version value is relevant.

Close #86.