### PR TITLE
Add mathml tag check

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "content-tag": "^2.0.1",
     "eslint-scope": "^7.2.2",
     "html-tags": "^3.3.1",
+    "mathml-tag-names": "^2.1.3",
     "svg-tags": "^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       mathml-tag-names:
-        specifier: 2.1.3
+        specifier: ^2.1.3
         version: 2.1.3
       svg-tags:
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       html-tags:
         specifier: ^3.3.1
         version: 3.3.1
+      mathml-tag-names:
+        specifier: 2.1.3
+        version: 2.1.3
       svg-tags:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3371,6 +3374,9 @@ packages:
   matcher-collection@2.0.1:
     resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  mathml-tag-names@2.1.3:
+    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
@@ -8948,6 +8954,8 @@ snapshots:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
+
+  mathml-tag-names@2.1.3: {}
 
   mdn-data@2.0.30: {}
 

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -5,6 +5,7 @@ const { visitorKeys: glimmerVisitorKeys } = require('@glimmer/syntax');
 const { Reference, Scope, Variable, Definition } = require('eslint-scope');
 const htmlTags = require('html-tags');
 const svgTags = require('svg-tags');
+const mathMLTags = require('mathml-tag-names');
 
 let TypescriptScope = null;
 try {
@@ -489,7 +490,7 @@ module.exports.convertAst = function convertAst(result, preprocessedResult, visi
       if we do not find a variable we register it with a missing variable if
         * it starts with upper case, it should be a component with a reference
         * it includes a dot, it's a path which should have a reference
-        * it's NOT a standard html or svg tag, it should have a referenced variable
+        * it's NOT a standard html, svg or mathml tag, it should have a referenced variable
       */
       const ignore =
         // Local instance access
@@ -507,7 +508,9 @@ module.exports.convertAst = function convertAst(result, preprocessedResult, visi
       const registerUndef =
         isUpperCase(n.name[0]) ||
         node.name.includes('.') ||
-        (!htmlTags.includes(node.name) && !svgTags.includes(node.name));
+        (!htmlTags.includes(node.name) &&
+          !svgTags.includes(node.name) &&
+          !mathMLTags.includes(node.name));
 
       if (!ignore && (variable || registerUndef)) {
         registerNodeInScope(n, scope, variable);

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2721,6 +2721,24 @@ export const NotFound = <template>
     expect(result.scopeManager.scopes[0].through.length).toBe(0);
   });
 
+  it('mathml elements are not added to global scope', () => {
+    result = parseForESLint(
+      `<template>
+        <math><msqrt><mi>x</mi></msqrt></math>
+        <mi>x</mi>
+      </template>`,
+      {
+        filePath: 'example.gts',
+        comment: true,
+        loc: true,
+        range: true,
+        tokens: true,
+      }
+    );
+
+    expect(result.scopeManager.scopes[0].through.length).toBe(0);
+  });
+
   it('custom-elements are ignored entirely, like they are in the browser', () => {
     result = parseForESLint(
       `<template>


### PR DESCRIPTION
Similar to SVG elements we should allow mathml to be written without warning they don't exist.

Will be more relevant when glimmer supports mathml, but no reason to hold up this end.