### PR TITLE
Fix resolving of peer deps

### DIFF
--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -9,9 +9,12 @@ const mathMLTags = require('mathml-tag-names');
 
 let TypescriptScope = null;
 try {
-  const path = require.resolve('@typescript-eslint/parser');
+  const parserPath = require.resolve('@typescript-eslint/parser');
   // eslint-disable-next-line n/no-unpublished-require
-  TypescriptScope = require('@typescript-eslint/scope-manager', { paths: [path] });
+  const scopeManagerPath = require.resolve('@typescript-eslint/scope-manager', {
+    paths: [parserPath],
+  });
+  TypescriptScope = require(scopeManagerPath);
 } catch {
   // not available
 }

--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -5,9 +5,10 @@ const { replaceRange } = require('./transforms');
 let patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser, isPatched;
 
 try {
-  const tsPath = require.resolve('@typescript-eslint/parser');
+  const parserPath = require.resolve('@typescript-eslint/parser');
   // eslint-disable-next-line n/no-unpublished-require
-  const ts = require('typescript', { paths: [tsPath] });
+  const tsPath = require.resolve('typescript', { paths: [parserPath] });
+  const ts = require(tsPath);
   typescriptParser = require('@typescript-eslint/parser');
   patchTs = function patchTs() {
     if (isPatched) {


### PR DESCRIPTION
In a pnpm monorepo, I was getting `Please install typescript to process gts`, although the setup seemed fine. Admittedly there were multiple copies of this package, however I _think_ this shouldn't be a problem when pnpm is correctly isolating workspaces and their dependency graph. 

https://github.com/ember-tooling/ember-eslint-parser/pull/82 introduced resolving `typescript` as a peer dependency from `@typescript-eslint/parser`, but I don't think this ever worked as intended. This PR should fix that.