### PR TITLE
Fix lint-fixing with typescript-eslint 8

### DIFF
--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -110,6 +110,7 @@ try {
             path: mtsSourceFile.path,
             originalFileName: mtsSourceFile.originalFileName,
             resolvedPath: mtsSourceFile.resolvedPath,
+            impliedNodeFormat: mtsSourceFile.impliedNodeFormat,
           };
           Object.assign(mtsSourceFile, sourceFile, keep);
           mtsSourceFile.isVirtualGts = true;


### PR DESCRIPTION
In the `sourceFile` objects that `typescript` manages, `gts` files end up with an `impliedNodeFormat` of `undefined` and `mts` files end up with an `impliedNodeFormat` of `99`. The buckets that `typescript` uses to cache the source files are keyed by their format, so when we run this syncing logic on an existing `mts` file we were overwriting its `impliedNodeFormat` and setting it to `undefined`. Perhaps something changed in `typescript-eslint@8` to take advantage of more caching or program reuse, not sure, but the result is that overwriting the `impliedNodeFormat` of the `mts` files that correspond to un-fixed `gts` files causes the error in #119. Adding it to the list of fields to preserve fixes it in all the cases I've run.

Fixes #119