### PR TITLE
Fix ESM babel configs

### DIFF
--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -1,5 +1,5 @@
 const tsconfigUtils = require('@typescript-eslint/tsconfig-utils');
-const babelParser = require('@babel/eslint-parser');
+const babelParser = require('@babel/eslint-parser/experimental-worker');
 const { registerParsedFile } = require('../preprocessor/noop');
 const {
   patchTs,


### PR DESCRIPTION
When using the eslint babel parser, we can't load any ESM babel config without this change.

This support in @babel/eslint-parser is "experimental" in the sense that it can't be made default until babel 8, but it works fine on our supported node range on babel 7.