### PR TITLE
Integrate Glint for current-file TS transform (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,16 +59,20 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.23.6",
+    "@glint/ember-tsc": ">= 1.1.0",
     "@typescript-eslint/parser": "*"
   },
   "peerDependenciesMeta": {
+    "@glint/ember-tsc": {
+      "optional": true
+    },
     "@typescript-eslint/parser": {
       "optional": true
     }
   },
   "packageManager": "pnpm@10.21.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.12.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@glimmer/syntax':
         specifier: '>= 0.92.0'
         version: 0.92.3
+      '@glint/ember-tsc':
+        specifier: '>= 1.1.0'
+        version: 1.1.1(typescript@5.7.2)
       '@typescript-eslint/tsconfig-utils':
         specifier: ^8.38.0
         version: 8.38.0(typescript@5.7.2)
@@ -141,7 +144,7 @@ importers:
         version: 3.0.8
       ember-source:
         specifier: ^6.1.0
-        version: 6.1.0(@glimmer/component@2.0.0)(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.94.0)
+        version: 6.1.0(@glimmer/component@2.0.0)(@glint/template@1.7.4)(rsvp@4.8.5)(webpack@5.94.0)
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -334,6 +337,45 @@ importers:
       typescript-eslint:
         specifier: ^8.19.1
         version: 8.19.1(eslint@8.57.1)(typescript@5.7.2)
+
+  test-projects/gts-glint:
+    devDependencies:
+      '@ember/test-waiters':
+        specifier: ^3.1.0
+        version: 3.1.0
+      '@glimmer/component':
+        specifier: ^1.1.2
+        version: 1.1.2(@babel/core@7.26.0)
+      '@glimmer/tracking':
+        specifier: ^1.1.2
+        version: 1.1.2
+      '@glint/ember-tsc':
+        specifier: ^1.1.0
+        version: 1.1.1(typescript@5.7.2)
+      '@glint/template':
+        specifier: ^1.3.0
+        version: 1.5.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.46.4
+        version: 8.46.4(@typescript-eslint/parser@8.46.4(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.46.4
+        version: 8.46.4(eslint@8.57.1)(typescript@5.7.2)
+      ember-eslint-parser:
+        specifier: workspace:*
+        version: link:../..
+      ember-source:
+        specifier: ^5.6.0
+        version: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.94.0)
+      eslint:
+        specifier: ^8.0.1
+        version: 8.57.1
+      eslint-plugin-ember:
+        specifier: ^12.0.0
+        version: 12.3.3(@typescript-eslint/parser@8.46.4(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.7.2
 
   test-projects/rules/padding-line-between-statements:
     devDependencies:
@@ -1309,8 +1351,17 @@ packages:
   '@glimmer/wire-format@0.94.8':
     resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
 
+  '@glint/ember-tsc@1.1.1':
+    resolution: {integrity: sha512-SEIyDPOv9nKpoXaRWp6rXrAnZu75GXW3MVg9nmxX0bwc0s2Aydpd/T0YjZux1ZJ0v8YevmFkBjlxk3UiSU3a6g==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.6.0'
+
   '@glint/template@1.5.0':
     resolution: {integrity: sha512-KyQUCWifxl8wDxo3SXzJcGKttHbIPgFBtqsoiu13Edx/o4CgGXr5rrM64jJR7Wvunn8sRM+Rq7Y0cHoB068Wuw==}
+
+  '@glint/template@1.7.4':
+    resolution: {integrity: sha512-39gTESXJmiIzJhcweJQ+44eIX+n+alJpD6HKpX8nPXCggVu2Yq6KP9pA5gwUvWE1/NYZhITiOqdA7UuyVtWMww==}
 
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
@@ -1819,6 +1870,32 @@ packages:
 
   '@vitest/utils@1.6.0':
     resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-server@2.4.28':
+    resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/test-utils@2.4.28':
+    resolution: {integrity: sha512-N7RNiHHDPtqK5B21x4W462XMQj7Z75ynN3isLP+3Rb44hbJjhxxDxzs+QqWB0sjM57EtTJga+SDd9WWy3OjMzA==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -2372,6 +2449,9 @@ packages:
 
   content-tag@2.0.3:
     resolution: {integrity: sha512-htLIdtfhhKW2fHlFLnZH7GFzHSdSpHhDLrWVswkNiiPMZ5uXq5JfrGboQKFhNQuAAFF8VNB2EYUj3MsdJrKKpg==}
+
+  content-tag@3.1.3:
+    resolution: {integrity: sha512-4Kiv9mEroxuMXfWUNUHcljVJgxThCNk7eEswdHMXdzJnkBBaYDqDwzHkoh3F74JJhfU3taJOsgpR6oEGIDg17g==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4142,6 +4222,9 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -4412,6 +4495,9 @@ packages:
   remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
 
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4659,10 +4745,6 @@ packages:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
 
-  source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4905,9 +4987,6 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
-  tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4973,6 +5052,12 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
   typescript-eslint@8.19.1:
     resolution: {integrity: sha512-LKPUQpdEMVOeKluHi8md7rwLcoXHhwvWp3x+sJkMuq3gGm9yaYJtPo8sRZSblMFJ5pcOGCAak/scKf1mvZDlQw==}
@@ -5135,6 +5220,48 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  volar-service-html@0.0.70:
+    resolution: {integrity: sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.70:
+    resolution: {integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-html-languageservice@5.6.2:
+    resolution: {integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   walk-sync@0.3.4:
     resolution: {integrity: sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==}
@@ -6064,7 +6191,7 @@ snapshots:
       '@babel/parser': 7.26.3
       '@babel/template': 7.25.9
       '@babel/types': 7.26.3
-      debug: 4.4.0
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6125,6 +6252,21 @@ snapshots:
       semver: 7.6.3
     optionalDependencies:
       '@glint/template': 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/macros@1.16.10(@glint/template@1.7.4)':
+    dependencies:
+      '@embroider/shared-internals': 2.8.1
+      assert-never: 1.4.0
+      babel-import-util: 2.1.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.6.3
+    optionalDependencies:
+      '@glint/template': 1.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -6504,7 +6646,31 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
+  '@glint/ember-tsc@1.1.1(typescript@5.7.2)':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': 1.7.4
+      '@volar/kit': 2.4.28(typescript@5.7.2)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 3.1.3
+      silent-error: 1.1.1
+      typescript: 5.7.2
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@glint/template@1.5.0': {}
+
+  '@glint/template@1.7.4': {}
 
   '@handlebars/parser@2.0.0': {}
 
@@ -7132,6 +7298,55 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@volar/kit@2.4.28(typescript@5.7.2)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 5.7.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-server@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/test-utils@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vscode/l10n@0.0.18': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -7908,6 +8123,8 @@ snapshots:
 
   content-tag@2.0.3: {}
 
+  content-tag@3.1.3: {}
+
   convert-source-map@2.0.0: {}
 
   core-js-compat@3.40.0:
@@ -7943,7 +8160,7 @@ snapshots:
   css-tree@3.1.0:
     dependencies:
       mdn-data: 2.12.2
-      source-map-js: 1.0.2
+      source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
 
@@ -8039,7 +8256,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8069,6 +8286,49 @@ snapshots:
       '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@embroider/macros': 1.16.10(@glint/template@1.5.0)
+      '@embroider/shared-internals': 2.8.1
+      babel-loader: 8.4.1(@babel/core@7.26.0)(webpack@5.94.0)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.3.0
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7(webpack@5.94.0)
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.94.0)
+      minimatch: 3.1.2
+      parse5: 6.0.1
+      pkg-entry-points: 1.1.1
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      semver: 7.6.3
+      style-loader: 2.0.0(webpack@5.94.0)
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
+  ember-auto-import@2.10.0(@glint/template@1.7.4)(webpack@5.94.0):
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.0)
+      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
+      '@embroider/macros': 1.16.10(@glint/template@1.7.4)
       '@embroider/shared-internals': 2.8.1
       babel-loader: 8.4.1(@babel/core@7.26.0)(webpack@5.94.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -8303,7 +8563,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-source@6.1.0(@glimmer/component@2.0.0)(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.94.0):
+  ember-source@6.1.0(@glimmer/component@2.0.0)(@glint/template@1.7.4)(rsvp@4.8.5)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.26.0
       '@ember/edition-utils': 1.2.0
@@ -8332,7 +8592,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.10.0(@glint/template@1.5.0)(webpack@5.94.0)
+      ember-auto-import: 2.10.0(@glint/template@1.7.4)(webpack@5.94.0)
       ember-cli-babel: 8.2.0(@babel/core@7.26.0)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -9967,7 +10227,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   lru-cache@10.4.3: {}
 
@@ -10155,7 +10415,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   node-releases@2.0.19: {}
 
@@ -10356,6 +10616,8 @@ snapshots:
   parse5@5.1.1: {}
 
   parse5@6.0.1: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
 
@@ -10638,6 +10900,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  request-light@0.7.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -10919,7 +11183,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   socks-proxy-agent@6.2.1:
     dependencies:
@@ -10933,8 +11197,6 @@ snapshots:
     dependencies:
       ip: 2.0.0
       smart-buffer: 4.2.0
-
-  source-map-js@1.0.2: {}
 
   source-map-js@1.2.1: {}
 
@@ -11203,8 +11465,6 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.6.2: {}
-
   tslib@2.8.1: {}
 
   type-check@0.4.0:
@@ -11308,6 +11568,12 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
+
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.6.3
 
   typescript-eslint@8.19.1(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
@@ -11474,6 +11740,51 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  volar-service-html@0.0.70(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.6.3
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-html-languageservice@5.6.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
 
   walk-sync@0.3.4:
     dependencies:

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -6,8 +6,16 @@ const {
   replaceExtensions,
   syncMtsGtsSourceFiles,
   typescriptParser,
+  ts,
 } = require('./ts-patch');
-const { transformForLint, preprocessGlimmerTemplates, convertAst } = require('./transforms');
+const {
+  transformForLint,
+  preprocessGlimmerTemplates,
+  preprocessGlimmerTemplatesFromCharOffsets,
+  convertAst,
+} = require('./transforms');
+const { isGlintAvailable, getGlintConfig, glintRewriteModule, buildTemplateInfoFromGlint } = require('./glint-utils');
+const { remapAstPositions, remapTokens } = require('./remap');
 
 /**
  * implements https://eslint.org/docs/latest/extend/custom-parsers
@@ -129,6 +137,83 @@ function getAllowJs(options) {
 }
 
 /**
+ * Parse using Glint's transform for full type-aware template support.
+ * Glint transforms templates into __glintDSL__ calls that TS understands,
+ * then we remap AST positions back to original source and splice in Glimmer AST.
+ */
+function parseWithGlint(code, options, transformedModule, allowGjsWasSet, actualAllowGjs, allowGjs) {
+  const filePath = options.filePath;
+
+  // Get transformed TS code and replace .gts→.mts imports
+  let tsCode = transformedModule.transformedContents;
+  if (options.project || options.projectService) {
+    tsCode = replaceExtensions(tsCode);
+  }
+
+  // Parse the transformed code with TS parser (positions in transformed-space)
+  const result = typescriptParser.parseForESLint(tsCode, {
+    ...options,
+    ranges: true,
+    extraFileExtensions: ['.gts', '.gjs'],
+    filePath,
+  });
+
+  // Build template infos from Glint's correlatedSpans
+  const glintTemplateInfos = buildTemplateInfoFromGlint(transformedModule, filePath);
+
+  // Always remap positions even if no templates — Glint may have changed code length
+  // for non-template spans (e.g., directive placeholders)
+  const { templateSpans } = remapAstPositions(
+    result.ast,
+    result.visitorKeys,
+    transformedModule.correlatedSpans,
+    code
+  );
+
+  // Remap tokens
+  result.ast.tokens = remapTokens(
+    result.ast.tokens,
+    transformedModule.correlatedSpans,
+    templateSpans,
+    code
+  );
+
+  if (!glintTemplateInfos.length) {
+    return result;
+  }
+
+  // Preprocess Glimmer templates (parse to Glimmer AST with correct positions)
+  const preprocessedResult = preprocessGlimmerTemplatesFromCharOffsets(glintTemplateInfos, code);
+  preprocessedResult.code = code;
+  const { templateVisitorKeys } = preprocessedResult;
+  const visitorKeys = { ...result.visitorKeys, ...templateVisitorKeys };
+  result.isTypescript = true;
+
+  // Splice Glimmer AST into the remapped TS AST (matchByRangeOnly because
+  // Glint produces different node types than transformForLint)
+  convertAst(result, preprocessedResult, visitorKeys, { matchByRangeOnly: true });
+
+  if (result.services?.program) {
+    const programAllowJs = result.services.program.getCompilerOptions?.()?.allowJs;
+    if (
+      !allowGjsWasSet &&
+      programAllowJs !== undefined &&
+      actualAllowGjs !== undefined &&
+      actualAllowGjs !== programAllowJs
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[ember-eslint-parser] allowJs does not match the actual program. Consider setting allowGjs explicitly.\n' +
+          `    Current: ${allowGjs}, Program: ${programAllowJs}`
+      );
+    }
+    syncMtsGtsSourceFiles(result.services.program);
+  }
+
+  return { ...result, visitorKeys };
+}
+
+/**
  * @type {import('eslint').ParserModule}
  */
 module.exports = {
@@ -146,6 +231,26 @@ module.exports = {
       ({ allowGjs: actualAllowGjs } = patchTs({ allowGjs }));
     }
     registerParsedFile(options.filePath);
+
+    // Try Glint path for .gts/.gjs files when Glint is available
+    const isGts = options.filePath.endsWith('.gts');
+    const isGjs = options.filePath.endsWith('.gjs');
+    if ((isGts || isGjs) && isGlintAvailable() && ts && typescriptParser) {
+      try {
+        const glintConfig = getGlintConfig(options.filePath);
+        if (glintConfig) {
+          const glintTransform = glintRewriteModule(code, options.filePath, ts, glintConfig);
+          if (glintTransform) {
+            return parseWithGlint(code, options, glintTransform, allowGjsWasSet, actualAllowGjs, allowGjs);
+          }
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('[ember-eslint-parser] Glint path failed, falling back:', e.message);
+      }
+    }
+
+    // Existing (non-Glint) path
     let jsCode = code;
     const info = transformForLint(code, options.filePath);
     jsCode = info.output;

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -184,7 +184,6 @@ function parseWithGlint(code, options, transformedModule, allowGjsWasSet, actual
 
   // Preprocess Glimmer templates (parse to Glimmer AST with correct positions)
   const preprocessedResult = preprocessGlimmerTemplatesFromCharOffsets(glintTemplateInfos, code);
-  preprocessedResult.code = code;
   const { templateVisitorKeys } = preprocessedResult;
   const visitorKeys = { ...result.visitorKeys, ...templateVisitorKeys };
   result.isTypescript = true;
@@ -246,7 +245,7 @@ module.exports = {
         }
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.warn('[ember-eslint-parser] Glint path failed, falling back:', e.message);
+        console.warn('[ember-eslint-parser] Glint path failed, falling back:', e.stack || e.message);
       }
     }
 

--- a/src/parser/glint-utils.js
+++ b/src/parser/glint-utils.js
@@ -54,4 +54,33 @@ function glintRewriteModule(code, filePath, ts, config) {
   );
 }
 
-module.exports = { isGlintAvailable, getGlintConfig, glintRewriteModule };
+/**
+ * Build template info objects from a Glint TransformedModule's correlatedSpans.
+ * Returns template ranges in character (UTF-16) offsets suitable for
+ * preprocessGlimmerTemplatesFromCharOffsets.
+ *
+ * @param {object} transformedModule - Glint TransformedModule
+ * @param {string} originalFileName - original file path
+ * @returns {Array<{ range: [number, number], contentRange: [number, number] }>}
+ */
+function buildTemplateInfoFromGlint(transformedModule, originalFileName) {
+  const result = [];
+  for (const span of transformedModule.correlatedSpans) {
+    if (!span.glimmerAstMapping) continue;
+
+    const fullStart = span.originalStart;
+    const fullEnd = span.originalStart + span.originalLength;
+
+    // Use findTemplateAtOriginalOffset to get content bounds (excludes <template> tags)
+    const tplInfo = transformedModule.findTemplateAtOriginalOffset(originalFileName, fullStart);
+    if (!tplInfo) continue;
+
+    result.push({
+      range: [fullStart, fullEnd],
+      contentRange: [tplInfo.originalContentStart, tplInfo.originalContentEnd],
+    });
+  }
+  return result;
+}
+
+module.exports = { isGlintAvailable, getGlintConfig, glintRewriteModule, buildTemplateInfoFromGlint };

--- a/src/parser/glint-utils.js
+++ b/src/parser/glint-utils.js
@@ -65,10 +65,15 @@ function glintRewriteModule(code, filePath, ts, config) {
  */
 function buildTemplateInfoFromGlint(transformedModule, originalFileName) {
   const result = [];
+  const seen = new Set();
   for (const span of transformedModule.correlatedSpans) {
     if (!span.glimmerAstMapping) continue;
 
     const fullStart = span.originalStart;
+    // Deduplicate: multiple spans can map to the same original template
+    if (seen.has(fullStart)) continue;
+    seen.add(fullStart);
+
     const fullEnd = span.originalStart + span.originalLength;
 
     // Use findTemplateAtOriginalOffset to get content bounds (excludes <template> tags)

--- a/src/parser/glint-utils.js
+++ b/src/parser/glint-utils.js
@@ -1,0 +1,57 @@
+let glintAvailable = false;
+let rewriteModule, ConfigLoader;
+
+try {
+  ({ rewriteModule } = require('@glint/ember-tsc/transform'));
+  ({ ConfigLoader } = require('@glint/ember-tsc'));
+  glintAvailable = true;
+} catch {
+  // @glint/ember-tsc not installed or Node too old for ESM require()
+}
+
+const configLoader = glintAvailable ? new ConfigLoader() : null;
+
+/**
+ * @returns {boolean}
+ */
+function isGlintAvailable() {
+  return glintAvailable;
+}
+
+/**
+ * Loads and caches GlintConfig for the project containing filePath.
+ * Returns null if @glint/ember-tsc is not available or no glint
+ * environment is configured in the project's tsconfig.
+ * @param {string} filePath
+ * @returns {import('@glint/ember-tsc').GlintConfig | null}
+ */
+function getGlintConfig(filePath) {
+  if (!configLoader) return null;
+  try {
+    const config = configLoader.configForFile(filePath);
+    if (!config || config.environment.names.length === 0) return null;
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrites a .gts/.gjs module using Glint's template-to-TypeScript transform.
+ * Returns TransformedModule or null if no templates found / transform not needed.
+ * @param {string} code - file contents
+ * @param {string} filePath - absolute file path
+ * @param {*} ts - TypeScript instance
+ * @param {import('@glint/ember-tsc').GlintConfig} config - Glint config
+ * @returns {{ transformedContents: string } | null}
+ */
+function glintRewriteModule(code, filePath, ts, config) {
+  if (!rewriteModule) return null;
+  return rewriteModule(
+    ts,
+    { script: { filename: filePath, contents: code } },
+    config.environment
+  );
+}
+
+module.exports = { isGlintAvailable, getGlintConfig, glintRewriteModule };

--- a/src/parser/remap.js
+++ b/src/parser/remap.js
@@ -1,0 +1,216 @@
+const DocumentLines = require('../utils/document');
+
+/**
+ * Extract template spans (those with glimmerAstMapping) from correlatedSpans.
+ * @param {Array} correlatedSpans
+ * @returns {Array<{ transformedStart: number, transformedEnd: number, originalStart: number, originalEnd: number, span: object }>}
+ */
+function getTemplateSpans(correlatedSpans) {
+  const result = [];
+  for (const span of correlatedSpans) {
+    if (span.glimmerAstMapping) {
+      result.push({
+        transformedStart: span.transformedStart,
+        transformedEnd: span.transformedStart + span.transformedLength,
+        originalStart: span.originalStart,
+        originalEnd: span.originalStart + span.originalLength,
+        span,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Map a transformed-space offset back to original-space.
+ * Returns null if the offset is in the interior of a template span
+ * (those nodes will be replaced by Glimmer AST).
+ *
+ * @param {Array} correlatedSpans
+ * @param {Array} templateSpans - precomputed from getTemplateSpans
+ * @param {number} transformedOffset
+ * @returns {number|null}
+ */
+function remapOffset(correlatedSpans, templateSpans, transformedOffset) {
+  // Check if inside a template span
+  for (const tpl of templateSpans) {
+    if (transformedOffset === tpl.transformedStart) {
+      return tpl.originalStart;
+    }
+    if (transformedOffset === tpl.transformedEnd) {
+      return tpl.originalEnd;
+    }
+    if (transformedOffset > tpl.transformedStart && transformedOffset < tpl.transformedEnd) {
+      return null; // interior of template span
+    }
+  }
+
+  // Find the enclosing span and apply linear formula.
+  // Template spans are included but safe: if we reach here, the offset is not at a
+  // template boundary (handled above) and not in the interior (returned null above).
+  // For non-template spans, originalLength === transformedLength, so the formula is a
+  // simple offset shift.
+  for (const span of correlatedSpans) {
+    const spanEnd = span.transformedStart + span.transformedLength;
+    if (transformedOffset >= span.transformedStart && transformedOffset <= spanEnd) {
+      return transformedOffset - span.transformedStart + span.originalStart;
+    }
+  }
+
+  // Past the end of all spans — use last span's end boundary
+  if (correlatedSpans.length > 0) {
+    const last = correlatedSpans[correlatedSpans.length - 1];
+    const lastTransformedEnd = last.transformedStart + last.transformedLength;
+    const lastOriginalEnd = last.originalStart + last.originalLength;
+    if (transformedOffset >= lastTransformedEnd) {
+      return lastOriginalEnd + (transformedOffset - lastTransformedEnd);
+    }
+  }
+
+  return transformedOffset;
+}
+
+/**
+ * Walk the AST and remap all positions from transformed-space to original-space.
+ * Collects template nodes (whose range falls entirely within a template span)
+ * for later replacement with Glimmer AST.
+ *
+ * @param {object} ast - the parsed AST (mutated in-place)
+ * @param {object} visitorKeys - ESLint visitor keys
+ * @param {Array} correlatedSpans
+ * @param {string} originalCode - original source code
+ * @returns {{ templateNodes: Map }}
+ */
+function remapAstPositions(ast, visitorKeys, correlatedSpans, originalCode) {
+  const templateSpans = getTemplateSpans(correlatedSpans);
+  const originalDoc = new DocumentLines(originalCode);
+  const templateNodes = new Map(); // templateSpan -> shallowest node
+
+  function remapNode(node) {
+    if (!node || typeof node !== 'object' || !node.range) return;
+
+    const startOriginal = remapOffset(correlatedSpans, templateSpans, node.range[0]);
+    const endOriginal = remapOffset(correlatedSpans, templateSpans, node.range[1]);
+
+    // If both endpoints are inside a template span, this is a template node
+    if (startOriginal === null && endOriginal === null) {
+      // Find which template span contains this node
+      for (const tpl of templateSpans) {
+        if (node.range[0] >= tpl.transformedStart && node.range[1] <= tpl.transformedEnd) {
+          if (!templateNodes.has(tpl)) {
+            templateNodes.set(tpl, []);
+          }
+          templateNodes.get(tpl).push(node);
+          break;
+        }
+      }
+      return; // don't remap — will be replaced
+    }
+
+    // Remap positions. If one end is null (crosses boundary), use the template boundary.
+    let newStart = startOriginal;
+    let newEnd = endOriginal;
+
+    if (newStart === null) {
+      // Start is inside a template span — find the span and use its original start
+      for (const tpl of templateSpans) {
+        if (node.range[0] >= tpl.transformedStart && node.range[0] < tpl.transformedEnd) {
+          newStart = tpl.originalStart;
+          break;
+        }
+      }
+    }
+    if (newEnd === null) {
+      // End is inside a template span — find the span and use its original end
+      for (const tpl of templateSpans) {
+        if (node.range[1] > tpl.transformedStart && node.range[1] <= tpl.transformedEnd) {
+          newEnd = tpl.originalEnd;
+          break;
+        }
+      }
+    }
+
+    // If either endpoint is still null after fallback, skip this node
+    if (newStart === null || newEnd === null) return;
+
+    node.range = [newStart, newEnd];
+    node.start = newStart;
+    node.end = newEnd;
+    node.loc = {
+      start: originalDoc.offsetToPosition(newStart),
+      end: originalDoc.offsetToPosition(newEnd),
+    };
+  }
+
+  // Walk AST and remap all nodes
+  const queue = [ast];
+  while (queue.length > 0) {
+    const node = queue.pop();
+    if (!node || typeof node !== 'object') continue;
+
+    remapNode(node);
+
+    const keys = visitorKeys[node.type] || [];
+    for (const key of keys) {
+      const child = node[key];
+      if (!child) continue;
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item && typeof item === 'object' && item.type) {
+            queue.push(item);
+          }
+        }
+      } else if (child.type) {
+        queue.push(child);
+      }
+    }
+  }
+
+  return { templateNodes, templateSpans };
+}
+
+/**
+ * Remap tokens from transformed-space to original-space.
+ * Tokens inside template spans are discarded (replaced by Glimmer tokens later).
+ *
+ * @param {Array} tokens
+ * @param {Array} correlatedSpans
+ * @param {Array} templateSpans
+ * @param {string} originalCode
+ * @returns {Array} remapped non-template tokens
+ */
+function remapTokens(tokens, correlatedSpans, templateSpans, originalCode) {
+  const originalDoc = new DocumentLines(originalCode);
+  const remapped = [];
+
+  for (const token of tokens) {
+    // Skip tokens entirely within a template span
+    let inTemplate = false;
+    for (const tpl of templateSpans) {
+      if (token.range[0] >= tpl.transformedStart && token.range[1] <= tpl.transformedEnd) {
+        inTemplate = true;
+        break;
+      }
+    }
+    if (inTemplate) continue;
+
+    const newStart = remapOffset(correlatedSpans, templateSpans, token.range[0]);
+    const newEnd = remapOffset(correlatedSpans, templateSpans, token.range[1]);
+
+    if (newStart === null || newEnd === null) continue; // edge case: skip
+
+    token.range = [newStart, newEnd];
+    token.start = newStart;
+    token.end = newEnd;
+    token.loc = {
+      start: { ...originalDoc.offsetToPosition(newStart), index: newStart },
+      end: { ...originalDoc.offsetToPosition(newEnd), index: newEnd },
+    };
+
+    remapped.push(token);
+  }
+
+  return remapped;
+}
+
+module.exports = { getTemplateSpans, remapOffset, remapAstPositions, remapTokens };

--- a/src/parser/remap.js
+++ b/src/parser/remap.js
@@ -72,19 +72,17 @@ function remapOffset(correlatedSpans, templateSpans, transformedOffset) {
 
 /**
  * Walk the AST and remap all positions from transformed-space to original-space.
- * Collects template nodes (whose range falls entirely within a template span)
- * for later replacement with Glimmer AST.
+ * Nodes entirely inside a template span are skipped (replaced by Glimmer AST later).
  *
  * @param {object} ast - the parsed AST (mutated in-place)
  * @param {object} visitorKeys - ESLint visitor keys
  * @param {Array} correlatedSpans
  * @param {string} originalCode - original source code
- * @returns {{ templateNodes: Map }}
+ * @returns {{ templateSpans: Array }}
  */
 function remapAstPositions(ast, visitorKeys, correlatedSpans, originalCode) {
   const templateSpans = getTemplateSpans(correlatedSpans);
   const originalDoc = new DocumentLines(originalCode);
-  const templateNodes = new Map(); // templateSpan -> shallowest node
 
   function remapNode(node) {
     if (!node || typeof node !== 'object' || !node.range) return;
@@ -92,19 +90,9 @@ function remapAstPositions(ast, visitorKeys, correlatedSpans, originalCode) {
     const startOriginal = remapOffset(correlatedSpans, templateSpans, node.range[0]);
     const endOriginal = remapOffset(correlatedSpans, templateSpans, node.range[1]);
 
-    // If both endpoints are inside a template span, this is a template node
+    // If both endpoints are inside a template span, skip — will be replaced
     if (startOriginal === null && endOriginal === null) {
-      // Find which template span contains this node
-      for (const tpl of templateSpans) {
-        if (node.range[0] >= tpl.transformedStart && node.range[1] <= tpl.transformedEnd) {
-          if (!templateNodes.has(tpl)) {
-            templateNodes.set(tpl, []);
-          }
-          templateNodes.get(tpl).push(node);
-          break;
-        }
-      }
-      return; // don't remap — will be replaced
+      return;
     }
 
     // Remap positions. If one end is null (crosses boundary), use the template boundary.
@@ -166,7 +154,7 @@ function remapAstPositions(ast, visitorKeys, correlatedSpans, originalCode) {
     }
   }
 
-  return { templateNodes, templateSpans };
+  return { templateSpans };
 }
 
 /**

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -251,12 +251,14 @@ function tokenize(template, doc, startOffset) {
  * @param code
  * @return {{templateVisitorKeys: {}, comments: *[], templateInfos: {templateRange: *, range: *, replacedRange: *}[]}}
  */
-module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(info, code) {
-  const templateInfos = info.templateInfos.map((r) => ({
-    range: [r.contentRange.start, r.contentRange.end],
-    templateRange: [r.range.start, r.range.end],
-    utf16Range: [byteToCharIndex(code, r.range.start), byteToCharIndex(code, r.range.end)],
-  }));
+/**
+ * Shared Glimmer template processing logic.
+ * Takes normalized template infos (with utf16Range already computed) and processes them.
+ * @param {Array<{range: number[], templateRange: number[], utf16Range: number[]}>} templateInfos
+ * @param {string} code - original source code
+ * @param {Function} getTokenSource - function(tpl) returning the string to tokenize
+ */
+function processGlimmerTemplates(templateInfos, code, getTokenSource) {
   const templateVisitorKeys = {};
   const codeLines = new DocumentLines(code);
   const comments = [];
@@ -269,7 +271,7 @@ module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(
     const template = code.slice(...range);
     const docLines = new DocumentLines(template);
     const ast = glimmer.preprocess(template, { mode: 'codemod' });
-    ast.tokens = tokenize(sliceByteRange(code, ...tpl.templateRange), codeLines, tpl.utf16Range[0]);
+    ast.tokens = tokenize(getTokenSource(tpl), codeLines, tpl.utf16Range[0]);
     const allNodes = [];
     glimmer.traverse(ast, {
       All(node, path) {
@@ -282,8 +284,6 @@ module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(
         }
         if (node.type === 'TextNode') {
           n.value = node.chars;
-          // empty text nodes are not allowed, it's empty if its only whitespace or line terminators
-          // it's okay for AttrNodes
           if (n.value.trim().length !== 0 || n.parent.type === 'AttrNode') {
             textNodes.push(node);
           } else {
@@ -383,20 +383,14 @@ module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(
       if (idx >= 0) {
         parentBody.splice(idx, 1);
       }
-      // comment type can be a block comment or a line comment
-      // mark comments as always block comment, this works for eslint in all cases
       comment.type = 'Block';
     }
-    // tokens should not contain tokens of comments
     ast.tokens = ast.tokens.filter(
       (t) => !comments.some((c) => c.range[0] <= t.range[0] && c.range[1] >= t.range[1])
     );
-    // tokens should not contain tokens of text nodes, but represent the whole node
-    // remove existing tokens
     ast.tokens = ast.tokens.filter(
       (t) => !textNodes.some((c) => c.range[0] <= t.range[0] && c.range[1] >= t.range[1])
     );
-    // merge in text nodes
     let currentTextNode = textNodes.pop();
     for (let i = ast.tokens.length - 1; i >= 0; i--) {
       const t = ast.tokens[i];
@@ -416,6 +410,35 @@ module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(
     templateInfos,
     comments,
   };
+}
+
+module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(info, code) {
+  const templateInfos = info.templateInfos.map((r) => ({
+    range: [r.contentRange.start, r.contentRange.end],
+    templateRange: [r.range.start, r.range.end],
+    utf16Range: [byteToCharIndex(code, r.range.start), byteToCharIndex(code, r.range.end)],
+  }));
+  return processGlimmerTemplates(templateInfos, code, (tpl) =>
+    sliceByteRange(code, ...tpl.templateRange)
+  );
+};
+
+/**
+ * Variant of preprocessGlimmerTemplates for the Glint path.
+ * Template infos already have character (UTF-16) offsets — no byte→char conversion needed.
+ * @param {Array<{ range: [number, number], contentRange: [number, number] }>} glintTemplateInfos
+ * @param {string} code - original source code
+ */
+module.exports.preprocessGlimmerTemplatesFromCharOffsets = function preprocessGlimmerTemplatesFromCharOffsets(
+  glintTemplateInfos,
+  code
+) {
+  const templateInfos = glintTemplateInfos.map((r) => ({
+    range: [...r.contentRange],
+    templateRange: [...r.range],
+    utf16Range: [...r.range],
+  }));
+  return processGlimmerTemplates(templateInfos, code, (tpl) => code.slice(...tpl.templateRange));
 };
 
 /**
@@ -429,8 +452,11 @@ module.exports.preprocessGlimmerTemplates = function preprocessGlimmerTemplates(
  * @param preprocessedResult
  * @param visitorKeys
  */
-module.exports.convertAst = function convertAst(result, preprocessedResult, visitorKeys) {
+module.exports.convertAst = function convertAst(result, preprocessedResult, visitorKeys, options) {
   const templateInfos = preprocessedResult.templateInfos;
+  const matchByRangeOnly = options?.matchByRangeOnly || false;
+  // Track which templates have been matched to avoid double-matching
+  const matchedTemplates = new Set();
   let counter = 0;
   result.ast.comments.push(...preprocessedResult.comments);
 
@@ -445,25 +471,29 @@ module.exports.convertAst = function convertAst(result, preprocessedResult, visi
     const node = path.node;
     if (!node) return null;
 
-    if (
+    const typeMatches = matchByRangeOnly || (
       node.type === 'ExpressionStatement' ||
       node.type === 'StaticBlock' ||
       node.type === 'TemplateLiteral' ||
       node.type === 'ExportDefaultDeclaration'
-    ) {
+    );
+
+    if (typeMatches) {
       let range = node.range;
-      if (node.type === 'ExportDefaultDeclaration') {
+      if (node.type === 'ExportDefaultDeclaration' && node.declaration) {
         range = [node.declaration.range[0], node.declaration.range[1]];
       }
 
       const template = templateInfos.find(
         (t) =>
+          !matchedTemplates.has(t) &&
           t.utf16Range[0] === range[0] &&
           (t.utf16Range[1] === range[1] || t.utf16Range[1] === range[1] + 1)
       );
       if (!template) {
         return null;
       }
+      matchedTemplates.add(template);
       counter++;
       const ast = template.ast;
       Object.assign(node, ast);

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -243,15 +243,6 @@ function tokenize(template, doc, startOffset) {
 }
 
 /**
- * Preprocesses the template info, parsing the template content to Glimmer AST,
- * fixing the offsets and locations of all nodes
- * also calculates the block params locations & ranges
- * and adding it to the info
- * @param info
- * @param code
- * @return {{templateVisitorKeys: {}, comments: *[], templateInfos: {templateRange: *, range: *, replacedRange: *}[]}}
- */
-/**
  * Shared Glimmer template processing logic.
  * Takes normalized template infos (with utf16Range already computed) and processes them.
  * @param {Array<{range: number[], templateRange: number[], utf16Range: number[]}>} templateInfos
@@ -284,6 +275,8 @@ function processGlimmerTemplates(templateInfos, code, getTokenSource) {
         }
         if (node.type === 'TextNode') {
           n.value = node.chars;
+          // empty text nodes are not allowed, it's empty if its only whitespace or line terminators
+          // it's okay for AttrNodes
           if (n.value.trim().length !== 0 || n.parent.type === 'AttrNode') {
             textNodes.push(node);
           } else {
@@ -383,14 +376,20 @@ function processGlimmerTemplates(templateInfos, code, getTokenSource) {
       if (idx >= 0) {
         parentBody.splice(idx, 1);
       }
+      // comment type can be a block comment or a line comment
+      // mark comments as always block comment, this works for eslint in all cases
       comment.type = 'Block';
     }
+    // tokens should not contain tokens of comments
     ast.tokens = ast.tokens.filter(
       (t) => !comments.some((c) => c.range[0] <= t.range[0] && c.range[1] >= t.range[1])
     );
+    // tokens should not contain tokens of text nodes, but represent the whole node
+    // remove existing tokens
     ast.tokens = ast.tokens.filter(
       (t) => !textNodes.some((c) => c.range[0] <= t.range[0] && c.range[1] >= t.range[1])
     );
+    // merge in text nodes
     let currentTextNode = textNodes.pop();
     for (let i = ast.tokens.length - 1; i >= 0; i--) {
       const t = ast.tokens[i];
@@ -463,6 +462,7 @@ module.exports.convertAst = function convertAst(result, preprocessedResult, visi
   for (const ti of templateInfos) {
     const firstIdx = result.ast.tokens.findIndex((t) => t.range[0] === ti.utf16Range[0]);
     const lastIdx = result.ast.tokens.findIndex((t) => t.range[1] === ti.utf16Range[1]);
+    if (firstIdx === -1 || lastIdx === -1) continue;
     result.ast.tokens.splice(firstIdx, lastIdx - firstIdx + 1, ...ti.ast.tokens);
   }
 
@@ -471,12 +471,17 @@ module.exports.convertAst = function convertAst(result, preprocessedResult, visi
     const node = path.node;
     if (!node) return null;
 
-    const typeMatches = matchByRangeOnly || (
-      node.type === 'ExpressionStatement' ||
-      node.type === 'StaticBlock' ||
-      node.type === 'TemplateLiteral' ||
-      node.type === 'ExportDefaultDeclaration'
-    );
+    // Glint produces CallExpression for expression templates and StaticBlock for
+    // class-member templates (vs TemplateLiteral from transformForLint).
+    const typeMatches = matchByRangeOnly
+      ? (node.type === 'ExpressionStatement' ||
+         node.type === 'CallExpression' ||
+         node.type === 'StaticBlock' ||
+         node.type === 'ExportDefaultDeclaration')
+      : (node.type === 'ExpressionStatement' ||
+         node.type === 'StaticBlock' ||
+         node.type === 'TemplateLiteral' ||
+         node.type === 'ExportDefaultDeclaration');
 
     if (typeMatches) {
       let range = node.range;

--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -3,13 +3,13 @@ const { transformForLint } = require('./transforms');
 const { replaceRange } = require('./transforms');
 const { isGlintAvailable, getGlintConfig, glintRewriteModule } = require('./glint-utils');
 
-let patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser, isPatched, allowGjs;
+let patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser, isPatched, allowGjs, ts;
 
 try {
   const parserPath = require.resolve('@typescript-eslint/parser');
   // eslint-disable-next-line n/no-unpublished-require
   const tsPath = require.resolve('typescript', { paths: [parserPath] });
-  const ts = require(tsPath);
+  ts = require(tsPath);
   typescriptParser = require('@typescript-eslint/parser');
   patchTs = function patchTs(options = {}) {
     if (isPatched) return { allowGjs };
@@ -165,4 +165,5 @@ module.exports = {
   replaceExtensions,
   syncMtsGtsSourceFiles,
   typescriptParser,
+  ts,
 };

--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -1,6 +1,7 @@
 const fs = require('node:fs');
 const { transformForLint } = require('./transforms');
 const { replaceRange } = require('./transforms');
+const { isGlintAvailable, getGlintConfig, glintRewriteModule } = require('./glint-utils');
 
 let patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser, isPatched, allowGjs;
 
@@ -50,11 +51,28 @@ try {
           content = fs.readFileSync(fileName).toString();
         }
         if (fileName.endsWith('.gts') || (allowGjs && fileName.endsWith('.gjs'))) {
-          try {
-            content = transformForLint(content).output;
-          } catch (e) {
-            console.error('failed to transformForLint for gts/gjs processing');
-            console.error(e);
+          let transformed = false;
+          if (isGlintAvailable()) {
+            try {
+              const config = getGlintConfig(fileName);
+              if (config) {
+                const result = glintRewriteModule(content, fileName, ts, config);
+                if (result) {
+                  content = result.transformedContents;
+                  transformed = true;
+                }
+              }
+            } catch (e) {
+              // Glint transform failed, fall through to transformForLint
+            }
+          }
+          if (!transformed) {
+            try {
+              content = transformForLint(content).output;
+            } catch (e) {
+              console.error('failed to transformForLint for gts/gjs processing');
+              console.error(e);
+            }
           }
         }
         if (

--- a/test-projects/gts-glint/.eslintignore
+++ b/test-projects/gts-glint/.eslintignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo

--- a/test-projects/gts-glint/.eslintrc.cjs
+++ b/test-projects/gts-glint/.eslintrc.cjs
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  root: true,
+  rules: {
+    'no-unused-vars': ['error'],
+  },
+  overrides: [
+    {
+      files: ['**/*.{js,ts}'],
+      plugins: ['ember'],
+      parser: 'ember-eslint-parser',
+      extends: ['eslint:recommended', 'plugin:ember/recommended'],
+    },
+    {
+      files: ['**/*.gts'],
+      parser: 'ember-eslint-parser',
+      plugins: ['ember'],
+      extends: ['eslint:recommended', 'plugin:ember/recommended', 'plugin:ember/recommended-gts'],
+    },
+  ],
+};

--- a/test-projects/gts-glint/index.d.ts
+++ b/test-projects/gts-glint/index.d.ts
@@ -1,0 +1,1 @@
+import "ember-source/types/stable"

--- a/test-projects/gts-glint/package.json
+++ b/test-projects/gts-glint/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@test-project/gts-glint",
+  "private": true,
+  "scripts": {
+    "test:check": "eslint src --max-warnings=0"
+  },
+  "devDependencies": {
+    "@ember/test-waiters": "^3.1.0",
+    "@glimmer/tracking": "^1.1.2",
+    "@glimmer/component": "^1.1.2",
+    "@glint/ember-tsc": "^1.1.0",
+    "@glint/template": "^1.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.46.4",
+    "@typescript-eslint/parser": "^8.46.4",
+    "ember-eslint-parser": "workspace:^",
+    "ember-source": "^5.6.0",
+    "eslint": "^8.0.1",
+    "eslint-plugin-ember": "^12.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/test-projects/gts-glint/src/consumer.ts
+++ b/test-projects/gts-glint/src/consumer.ts
@@ -1,0 +1,5 @@
+import { greet } from './greeter';
+
+const message: string = greet('world');
+
+export { message };

--- a/test-projects/gts-glint/src/greeter.gts
+++ b/test-projects/gts-glint/src/greeter.gts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+interface GreeterArgs {
+  name: string;
+}
+
+export function greet(name: string): string {
+  return `Hello, ${name}`;
+}
+
+export default class Greeter extends Component<{ Args: GreeterArgs }> {
+  get greeting(): string {
+    return greet(this.args.name);
+  }
+
+  <template>
+    <div>{{this.greeting}}</div>
+  </template>
+}

--- a/test-projects/gts-glint/tsconfig.json
+++ b/test-projects/gts-glint/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["ES2018", "DOM"],
+    "module": "commonjs",
+    "experimentalDecorators": true,
+    "rootDir": ".",
+    "allowJs": true,
+    "strictNullChecks": true
+  },
+  "glint": {
+    "environment": "ember-template-imports"
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.gts",
+    "index.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a Glint-based parsing path for `.gts`/`.gjs` files that uses Glint's transform to produce `__glintDSL__` calls TypeScript understands, then remaps AST positions back to original source and splices in Glimmer AST
- New `remap.js` module handles offset mapping from Glint's transformed-space back to original-space for both AST nodes and tokens
- Refactors `preprocessGlimmerTemplates` into a shared `processGlimmerTemplates` core, with a new `preprocessGlimmerTemplatesFromCharOffsets` variant for the Glint path
- Extends `convertAst` with `matchByRangeOnly` option to handle Glint's different node types (CallExpression vs TemplateLiteral)
- Falls back gracefully to the existing non-Glint path on failure

## Test plan

- [ ] Verify existing tests still pass (non-Glint path unchanged)
- [ ] Test with a project that has Glint configured to validate the new path
- [ ] Add unit tests for `remapOffset`, `remapAstPositions`, `remapTokens`
- [ ] Add integration test for `parseWithGlint` with a simple `.gts` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)