### PR TITLE
hbs-parser: register block-param scope for `as |x|`

### DIFF
--- a/src/parser/hbs-parser.js
+++ b/src/parser/hbs-parser.js
@@ -1,6 +1,6 @@
 import * as eslintScope from 'eslint-scope';
 import { toTree, glimmerVisitorKeys, DocumentLines } from 'ember-estree';
-import { registerGlimmerScopes } from './transforms.js';
+import { registerHBSScopes } from './transforms.js';
 
 // Constant: Program + all Glimmer node types. Computed once at module load.
 const hbsVisitorKeys = { Program: ['body'], ...glimmerVisitorKeys };
@@ -80,10 +80,7 @@ export function parseForESLint(code, options) {
   scopeManager.__nodeToScope.delete(stubProgram);
   scopeManager.__nodeToScope.set(program, [globalScope]);
 
-  registerGlimmerScopes(
-    { ast: program, scopeManager, visitorKeys: hbsVisitorKeys, isTypescript: false },
-    { blockParamsOnly: true }
-  );
+  registerHBSScopes({ ast: program, scopeManager, visitorKeys: hbsVisitorKeys });
 
   return {
     ast: program,

--- a/src/parser/hbs-parser.js
+++ b/src/parser/hbs-parser.js
@@ -1,5 +1,6 @@
 import * as eslintScope from 'eslint-scope';
 import { toTree, glimmerVisitorKeys, DocumentLines } from 'ember-estree';
+import { registerGlimmerScopes } from './transforms.js';
 
 // Constant: Program + all Glimmer node types. Computed once at module load.
 const hbsVisitorKeys = { Program: ['body'], ...glimmerVisitorKeys };
@@ -64,26 +65,30 @@ export function parseForESLint(code, options) {
     },
   };
 
-  // Build visitor keys: Program + all Glimmer node types
-  const visitorKeys = hbsVisitorKeys;
+  // Analyze a stub Program then rebind the resulting global scope to the real
+  // Program. Analyzing the real Program directly causes infinite recursion in
+  // esrecurse because Glimmer subtree nodes carry parent back-links.
+  const stubProgram = {
+    type: 'Program',
+    body: [],
+    range: [0, code.length],
+    loc: program.loc,
+  };
+  const scopeManager = eslintScope.analyze(stubProgram, { range: true });
+  const globalScope = scopeManager.acquire(stubProgram);
+  globalScope.block = program;
+  scopeManager.__nodeToScope.delete(stubProgram);
+  scopeManager.__nodeToScope.set(program, [globalScope]);
 
-  // Create an empty scope manager.
-  // For HBS, all locals are assumed to be defined at runtime,
-  // so we don't track variable references (no no-undef errors).
-  const scopeManager = eslintScope.analyze(
-    {
-      type: 'Program',
-      body: [],
-      range: [0, code.length],
-      loc: program.loc,
-    },
-    { range: true }
+  registerGlimmerScopes(
+    { ast: program, scopeManager, visitorKeys: hbsVisitorKeys, isTypescript: false },
+    { blockParamsOnly: true }
   );
 
   return {
     ast: program,
     scopeManager,
-    visitorKeys,
+    visitorKeys: hbsVisitorKeys,
     services: {},
   };
 }

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -82,6 +82,7 @@ function isUpperCase(char) {
 
 function registerBlockParams(node, path, scopeManager, isTypescript) {
   const blockParamNodes = node.blockParamNodes || [];
+  if (blockParamNodes.length === 0) return;
   const upperScope = findParentScope(scopeManager, path);
   const scope = isTypescript
     ? new TypescriptScope.BlockScope(scopeManager, upperScope, node)
@@ -220,21 +221,28 @@ function traverse(visitorKeys, node, visitor) {
 }
 
 /**
- * Full AST traversal for scope registration — used as fallback for JS/oxc path.
- * For the TS path, toTree's visitor API handles this during splicing.
+ * Full AST traversal for scope registration — used as fallback for JS/oxc path
+ * and for the HBS parser. For the TS path, toTree's visitor API handles this
+ * during splicing.
+ *
+ * Pass `{ blockParamsOnly: true }` to skip PathExpression/ElementNode
+ * reference registration — used by HBS where free identifiers are treated as
+ * runtime-defined and must not surface as no-undef errors.
  */
-export function registerGlimmerScopes(result) {
+export function registerGlimmerScopes(result, { blockParamsOnly = false } = {}) {
   // eslint-disable-next-line complexity
   traverse(result.visitorKeys, result.ast, (path) => {
     const node = path.node;
     if (!node) return;
-    if (node.type === 'GlimmerPathExpression') {
-      registerPathExpression(node, path, result.scopeManager);
+    if (!blockParamsOnly) {
+      if (node.type === 'GlimmerPathExpression') {
+        registerPathExpression(node, path, result.scopeManager);
+      }
+      if (node.type === 'GlimmerElementNode') {
+        registerElementNode(node, path, result.scopeManager);
+      }
     }
-    if (node.type === 'GlimmerElementNode') {
-      registerElementNode(node, path, result.scopeManager);
-    }
-    if ('blockParams' in node && node.type?.startsWith('Glimmer')) {
+    if ('blockParams' in node && node.type.startsWith('Glimmer')) {
       registerBlockParams(node, path, result.scopeManager, result.isTypescript);
     }
   });

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -221,29 +221,38 @@ function traverse(visitorKeys, node, visitor) {
 }
 
 /**
- * Full AST traversal for scope registration — used as fallback for JS/oxc path
- * and for the HBS parser. For the TS path, toTree's visitor API handles this
- * during splicing.
- *
- * Pass `{ blockParamsOnly: true }` to skip PathExpression/ElementNode
- * reference registration — used by HBS where free identifiers are treated as
- * runtime-defined and must not surface as no-undef errors.
+ * Full AST traversal for scope registration — used as fallback for JS/oxc path.
+ * For the TS path, toTree's visitor API handles this during splicing.
  */
-export function registerGlimmerScopes(result, { blockParamsOnly = false } = {}) {
+export function registerGlimmerScopes(result) {
   // eslint-disable-next-line complexity
   traverse(result.visitorKeys, result.ast, (path) => {
     const node = path.node;
     if (!node) return;
-    if (!blockParamsOnly) {
-      if (node.type === 'GlimmerPathExpression') {
-        registerPathExpression(node, path, result.scopeManager);
-      }
-      if (node.type === 'GlimmerElementNode') {
-        registerElementNode(node, path, result.scopeManager);
-      }
+    if (node.type === 'GlimmerPathExpression') {
+      registerPathExpression(node, path, result.scopeManager);
     }
-    if ('blockParams' in node && node.type.startsWith('Glimmer')) {
+    if (node.type === 'GlimmerElementNode') {
+      registerElementNode(node, path, result.scopeManager);
+    }
+    if ('blockParams' in node && node.type?.startsWith('Glimmer')) {
       registerBlockParams(node, path, result.scopeManager, result.isTypescript);
+    }
+  });
+}
+
+/**
+ * Scope registration for the HBS parser. Unlike the gjs/gts path, we do not
+ * register references for free identifiers (`{{path}}`, `<Tag>`) — all
+ * template locals are treated as runtime-defined, so no-undef stays quiet.
+ * Only block params from `as |x|` constructs are declared.
+ */
+export function registerHBSScopes(result) {
+  traverse(result.visitorKeys, result.ast, (path) => {
+    const node = path.node;
+    if (!node) return;
+    if ('blockParams' in node && node.type.startsWith('Glimmer')) {
+      registerBlockParams(node, path, result.scopeManager, false);
     }
   });
 }

--- a/tests/hbs-parser.test.js
+++ b/tests/hbs-parser.test.js
@@ -118,6 +118,48 @@ describe('hbs-parser', () => {
     });
   });
 
+  describe('block-param scope', () => {
+    function findBlockParamVar(scopeManager, name) {
+      for (const scope of scopeManager.scopes) {
+        if (scope.type !== 'block') continue;
+        const v = scope.set.get(name);
+        if (v) return { scope, variable: v };
+      }
+      return null;
+    }
+
+    it('registers block params from <Foo as |x|>', () => {
+      const r = parseForESLint('<Foo as |x|>{{x}}</Foo>', { filePath: 'bp.hbs' });
+      const found = findBlockParamVar(r.scopeManager, 'x');
+      expect(found).not.toBeNull();
+      expect(found.variable.defs).toHaveLength(2);
+      expect(found.variable.defs[0].type).toBe('Parameter');
+    });
+
+    it('registers block params from {{#let ... as |router|}}', () => {
+      const r = parseForESLint('{{#let foo as |router|}}{{router}}{{/let}}', {
+        filePath: 'let.hbs',
+      });
+      const found = findBlockParamVar(r.scopeManager, 'router');
+      expect(found).not.toBeNull();
+    });
+
+    it('registers multiple block params', () => {
+      const r = parseForESLint('<Foo as |a b c|>{{a}}{{b}}{{c}}</Foo>', {
+        filePath: 'multi.hbs',
+      });
+      expect(findBlockParamVar(r.scopeManager, 'a')).not.toBeNull();
+      expect(findBlockParamVar(r.scopeManager, 'b')).not.toBeNull();
+      expect(findBlockParamVar(r.scopeManager, 'c')).not.toBeNull();
+    });
+
+    it('does not create block scopes for elements without `as |...|`', () => {
+      const r = parseForESLint('<Foo>hi</Foo>', { filePath: 'noparams.hbs' });
+      const blockScopes = r.scopeManager.scopes.filter((s) => s.type === 'block');
+      expect(blockScopes).toHaveLength(0);
+    });
+  });
+
   describe('lint rules', () => {
     let linter;
 


### PR DESCRIPTION
## Summary

Registers block-param scope in the HBS parser so `<Foo as |x|>` and `{{#let ... as |x|}}` create proper variable bindings in the scope manager. Previously the HBS parser analyzed an empty stub Program, so no block params landed in any scope.

## Why

Came up reviewing [ember-cli/eslint-plugin-ember#2689](https://github.com/ember-cli/eslint-plugin-ember/pull/2689) (`template-no-block-params-for-html-elements`). The lint rule's scope check is effectively dead code on `.hbs` files because the HBS parser never populates scope with template-defined variables — only the html-tag allowlist heuristic carries that case. Same gap likely affects any other rule that consults scope for HBS templates.

## Approach

- Adds a new `registerHBSScopes` in `transforms.js` that traverses the Glimmer AST and declares only block-param variables. Free identifiers (`{{path}}`, `<Tag>`) are intentionally left unregistered so HBS keeps its "all template locals are runtime-defined" policy and no-undef stays quiet. `registerGlimmerScopes` is unchanged.
- In `hbs-parser.js`, rebinds the analyzed global scope from a stub Program onto the real Program. Analyzing the real Program directly causes infinite recursion in esrecurse — the Glimmer subtree carries parent back-links.
- Drive-by: adds an early-exit to `registerBlockParams` when there are no block params, avoiding empty BlockScopes that would pollute `findParentScope`/`findVarInParentScopes` lookups (also benefits the gjs/gts path).

## Test plan

- [x] `<Foo as |x|>{{x}}</Foo>` — block scope with `x` declared
- [x] `{{#let foo as |router|}}{{router}}{{/let}}` — block scope with `router`
- [x] `<Foo as |a b c|>` — multiple params each registered
- [x] `<Foo>hi</Foo>` — no block scopes created
- [x] All existing tests still pass (36 total)
- [x] `pnpm lint` clean