### PR TITLE
fix: promote <template> comment nodes into Program.comments for ESLint directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@glimmer/syntax": "^0.95.0",
     "@typescript-eslint/tsconfig-utils": "^8.57.1",
     "content-tag": "^4.1.1",
-    "ember-estree": "^0.4.2",
+    "ember-estree": "^0.4.3",
     "eslint-scope": "^9.1.2",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-estree:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.4.3
+        version: 0.4.3
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
@@ -95,10 +95,10 @@ importers:
         version: 5.7.2
       vite:
         specifier: ^5.0.12
-        version: 5.4.11(@types/node@25.5.0)(terser@5.46.1)
+        version: 5.4.11(@types/node@25.6.0)(terser@5.46.1)
       vitest:
         specifier: ^1.2.2
-        version: 1.6.0(@types/node@25.5.0)(terser@5.46.1)
+        version: 1.6.0(@types/node@25.6.0)(terser@5.46.1)
 
   test-projects/configs/flat-js:
     dependencies:
@@ -1848,6 +1848,7 @@ packages:
 
   '@tsconfig/ember@3.0.8':
     resolution: {integrity: sha512-OVnIsZIt/8q0VEtcdz3rRryNrm6gdJTxXlxefkGIrkZnME0wqslmwHlUEZ7mvh377df9FqBhNKrYNarhCW8zJA==}
+    deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1882,8 +1883,8 @@ packages:
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/rimraf@2.0.5':
     resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
@@ -2372,8 +2373,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.10.9:
-    resolution: {integrity: sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==}
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2401,8 +2402,8 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -2496,6 +2497,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2551,8 +2557,8 @@ packages:
   caniuse-lite@1.0.30001754:
     resolution: {integrity: sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==}
 
-  caniuse-lite@1.0.30001780:
-    resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
@@ -2787,8 +2793,8 @@ packages:
   electron-to-chromium@1.5.250:
     resolution: {integrity: sha512-/5UMj9IiGDMOFBnN4i7/Ry5onJrAGSbOGo3s9FEKmwobGq6xw832ccET0CE3CkkMBZ8GJSlUIesZofpyurqDXw==}
 
-  electron-to-chromium@1.5.321:
-    resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
+  electron-to-chromium@1.5.343:
+    resolution: {integrity: sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==}
 
   electron-to-chromium@1.5.78:
     resolution: {integrity: sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==}
@@ -2849,8 +2855,8 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-estree@0.4.2:
-    resolution: {integrity: sha512-Runf+IVY+hUhlk0QwwljhPYj0/kjza5CCRp/Hlfdk9MawKSxXQqR0WX4f2rChXAGbDIzK7JVopVaet5oIZr8tg==}
+  ember-estree@0.4.3:
+    resolution: {integrity: sha512-742Wp/Dx2g9IZFOd9+JaRTpyflptxhtdMaG7MA2nl8lZOM9zTzlD+FfT3Vx/o+CZX976ZGDBbKg/gr5WErfqxA==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -4037,8 +4043,8 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -4240,8 +4246,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
@@ -5116,8 +5122,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar@6.2.0:
@@ -5315,8 +5321,8 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -5730,7 +5736,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -6629,7 +6635,7 @@ snapshots:
       fs-extra: 9.1.0
       is-subdir: 1.2.0
       js-string-escape: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 3.1.5
       pkg-entry-points: 1.1.1
       resolve-package-path: 4.0.3
@@ -7445,9 +7451,9 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/node@25.5.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/rimraf@2.0.5':
     dependencies:
@@ -8222,7 +8228,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.10.9: {}
+  baseline-browser-mapping@2.10.21: {}
 
   baseline-browser-mapping@2.8.27: {}
 
@@ -8243,7 +8249,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -8441,11 +8447,19 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.9
-      caniuse-lite: 1.0.30001780
-      electron-to-chromium: 1.5.321
-      node-releases: 2.0.36
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.343
+      node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.343
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
@@ -8525,7 +8539,7 @@ snapshots:
 
   caniuse-lite@1.0.30001754: {}
 
-  caniuse-lite@1.0.30001780: {}
+  caniuse-lite@1.0.30001790: {}
 
   chai@4.5.0:
     dependencies:
@@ -8764,7 +8778,7 @@ snapshots:
 
   electron-to-chromium@1.5.250: {}
 
-  electron-to-chromium@1.5.321: {}
+  electron-to-chromium@1.5.343: {}
 
   electron-to-chromium@1.5.78: {}
 
@@ -8979,7 +8993,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-estree@0.4.2:
+  ember-estree@0.4.3:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/syntax': 0.95.0
@@ -9171,7 +9185,7 @@ snapshots:
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   ensure-posix-path@1.1.1: {}
 
@@ -10656,7 +10670,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10780,7 +10794,7 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loupe@2.3.7:
     dependencies:
@@ -10887,7 +10901,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.6:
     dependencies:
@@ -10988,7 +11002,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.38: {}
 
   npm-bundled@2.0.1:
     dependencies:
@@ -11976,7 +11990,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
   tar@6.2.0:
     dependencies:
@@ -12223,7 +12237,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -12270,6 +12284,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -12285,13 +12305,13 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
-  vite-node@1.6.0(@types/node@25.5.0)(terser@5.46.1):
+  vite-node@1.6.0(@types/node@25.6.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.11(@types/node@25.5.0)(terser@5.46.1)
+      vite: 5.4.11(@types/node@25.6.0)(terser@5.46.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12303,17 +12323,17 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@25.5.0)(terser@5.46.1):
+  vite@5.4.11(@types/node@25.6.0)(terser@5.46.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.30.1
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       terser: 5.46.1
 
-  vitest@1.6.0(@types/node@25.5.0)(terser@5.46.1):
+  vitest@1.6.0(@types/node@25.6.0)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -12332,11 +12352,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.11(@types/node@25.5.0)(terser@5.46.1)
-      vite-node: 1.6.0(@types/node@25.5.0)(terser@5.46.1)
+      vite: 5.4.11(@types/node@25.6.0)(terser@5.46.1)
+      vite-node: 1.6.0(@types/node@25.6.0)(terser@5.46.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12400,7 +12420,7 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      tapable: 2.3.0
+      tapable: 2.3.3
       terser-webpack-plugin: 5.4.0(webpack@5.94.0)
       watchpack: 2.5.1
       webpack-sources: 3.3.4

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -201,6 +201,13 @@ export function parseForESLint(code, options) {
 
     if (!result.scopeManager) result.scopeManager = scopeManager;
 
+    // ember-estree 0.4.3 (NullVoxPopuli/ember-estree#31) keeps Glimmer comment
+    // nodes inside the template body instead of mirroring them into
+    // Program.comments. ESLint's inline-config scanner only reads
+    // Program.comments, so `{{! eslint-disable-* }}` directives inside
+    // <template> would be silently dropped. Promote them here.
+    promoteTemplateCommentsToProgram(result);
+
     if (result.services?.program) {
       const programAllowJs = result.services.program.getCompilerOptions?.()?.allowJs;
       if (
@@ -239,6 +246,41 @@ export function parseForESLint(code, options) {
       throw err;
     }
     throw e;
+  }
+}
+
+/**
+ * Walk each spliced Glimmer template subtree and append its comment nodes
+ * (GlimmerCommentStatement for `<!-- -->`, GlimmerMustacheCommentStatement for
+ * `{{! }}` / `{{!-- --}}`) to `result.ast.comments`, so ESLint's inline-config
+ * scanner can see disable/enable directives placed inside templates.
+ *
+ * @param {{ ast: { comments?: unknown[] }, templateInfos?: Array<{ ast: unknown }> }} result
+ */
+function promoteTemplateCommentsToProgram(result) {
+  const templateInfos = result.templateInfos;
+  if (!templateInfos || templateInfos.length === 0) return;
+  if (!result.ast.comments) result.ast.comments = [];
+  const comments = result.ast.comments;
+  for (const { ast } of templateInfos) {
+    collectGlimmerComments(ast, comments);
+  }
+}
+
+function collectGlimmerComments(node, out) {
+  if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
+  if (node.type === 'GlimmerCommentStatement' || node.type === 'GlimmerMustacheCommentStatement') {
+    out.push(node);
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === 'parent' || key === 'loc' || key === 'range' || key === 'tokens') continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const child of value) collectGlimmerComments(child, out);
+    } else {
+      collectGlimmerComments(value, out);
+    }
   }
 }
 

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -250,10 +250,27 @@ export function parseForESLint(code, options) {
 }
 
 /**
- * Walk each spliced Glimmer template subtree and append its comment nodes
- * (GlimmerCommentStatement for `<!-- -->`, GlimmerMustacheCommentStatement for
- * `{{! }}` / `{{!-- --}}`) to `result.ast.comments`, so ESLint's inline-config
- * scanner can see disable/enable directives placed inside templates.
+ * Expose template comments to ESLint. ember-estree 0.4.3+
+ * (NullVoxPopuli/ember-estree#31) keeps `GlimmerCommentStatement` /
+ * `GlimmerMustacheCommentStatement` nodes in the template body and
+ * does not touch `Program.comments`. That breaks two things ESLint
+ * consumers rely on:
+ *
+ *  1. ESLint's inline-config scanner reads `Program.comments`, so
+ *     `{{! eslint-disable-* }}` directives inside <template> are
+ *     silently ignored.
+ *  2. Rules that iterate `sourceCode.getAllComments()` expecting
+ *     pre-0.4.3's ESTree `"Block"` type (e.g. template-no-html-comments)
+ *     no longer match. And core rules like `indent` call
+ *     `getLastToken(commentNode)` which returns null for in-body
+ *     comments (they own no tokens), then crash dereferencing `.loc`.
+ *
+ * Restore the pre-0.4.3 ESLint-facing contract: push Block-typed
+ * comment entries into `ast.comments` (sorted by range so
+ * `sortedMerge` stays well-ordered) and remove the original nodes
+ * from their parents so rule visitors and core `indent` don't trip
+ * over tokenless body children. ember-estree keeps its new internal
+ * shape; this adaptation lives at the parser boundary.
  *
  * @param {{ ast: { comments?: unknown[] }, templateInfos?: Array<{ ast: unknown }> }} result
  */
@@ -262,25 +279,48 @@ function promoteTemplateCommentsToProgram(result) {
   if (!templateInfos || templateInfos.length === 0) return;
   if (!result.ast.comments) result.ast.comments = [];
   const comments = result.ast.comments;
+  const toRemove = [];
   for (const { ast } of templateInfos) {
-    collectGlimmerComments(ast, comments);
+    collectGlimmerComments(ast, comments, toRemove);
   }
+  if (toRemove.length === 0) return;
+  removeFromParent(toRemove);
+  comments.sort((a, b) => a.range[0] - b.range[0]);
 }
 
-function collectGlimmerComments(node, out) {
+function collectGlimmerComments(node, out, toRemove) {
   if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
   if (node.type === 'GlimmerCommentStatement' || node.type === 'GlimmerMustacheCommentStatement') {
-    out.push(node);
+    out.push({
+      type: 'Block',
+      value: node.value,
+      range: node.range,
+      start: node.start,
+      end: node.end,
+      loc: node.loc,
+    });
+    toRemove.push(node);
     return;
   }
   for (const key of Object.keys(node)) {
     if (key === 'parent' || key === 'loc' || key === 'range' || key === 'tokens') continue;
     const value = node[key];
     if (Array.isArray(value)) {
-      for (const child of value) collectGlimmerComments(child, out);
+      for (const child of value) collectGlimmerComments(child, out, toRemove);
     } else {
-      collectGlimmerComments(value, out);
+      collectGlimmerComments(value, out, toRemove);
     }
+  }
+}
+
+function removeFromParent(nodes) {
+  for (const node of nodes) {
+    const parent = node.parent;
+    if (!parent) continue;
+    const children = parent.children || parent.body || parent.parts;
+    if (!children) continue;
+    const idx = children.indexOf(node);
+    if (idx >= 0) children.splice(idx, 1);
   }
 }
 

--- a/src/parser/hbs-parser.js
+++ b/src/parser/hbs-parser.js
@@ -46,6 +46,32 @@ export function parseForESLint(code, options) {
 
   const { ast: templateNode, comments } = result;
 
+  // ember-estree 0.4.3+ keeps Glimmer comment nodes in the template body with
+  // semantic Glimmer types. For ESLint consumers we restore the pre-0.4.3
+  // contract: expose Block-typed entries in Program.comments (so inline-config
+  // directives fire and rules that filter on `type === 'Block'` keep working)
+  // and remove the originals from the body (so rules like core `indent`, which
+  // call getLastToken on body children, don't crash on tokenless comments).
+  const eslintComments = [];
+  const toRemove = [];
+  for (const c of comments) {
+    if (c.type === 'GlimmerCommentStatement' || c.type === 'GlimmerMustacheCommentStatement') {
+      eslintComments.push({
+        type: 'Block',
+        value: c.value,
+        range: c.range,
+        start: c.start,
+        end: c.end,
+        loc: c.loc,
+      });
+      toRemove.push(c);
+    } else {
+      eslintComments.push(c);
+    }
+  }
+  removeFromParent(toRemove);
+  eslintComments.sort((a, b) => a.range[0] - b.range[0]);
+
   // Use the Template node's loc.end for the Program's end position
   // (avoids creating a duplicate DocumentLines just for this)
   const endLoc = templateNode.loc?.end || { line: 1, column: code.length };
@@ -55,7 +81,7 @@ export function parseForESLint(code, options) {
     type: 'Program',
     body: [templateNode],
     tokens: templateNode.tokens,
-    comments,
+    comments: eslintComments,
     range: [0, code.length],
     start: 0,
     end: code.length,
@@ -88,6 +114,17 @@ export function parseForESLint(code, options) {
     visitorKeys: hbsVisitorKeys,
     services: {},
   };
+}
+
+function removeFromParent(nodes) {
+  for (const node of nodes) {
+    const parent = node.parent;
+    if (!parent) continue;
+    const children = parent.children || parent.body || parent.parts;
+    if (!children) continue;
+    const idx = children.indexOf(node);
+    if (idx >= 0) children.splice(idx, 1);
+  }
 }
 
 export default { meta, parseForESLint };

--- a/tests/hbs-parser.test.js
+++ b/tests/hbs-parser.test.js
@@ -83,12 +83,6 @@ describe('hbs-parser', () => {
   it('all nodes have tokens', () => {
     const source = new SourceCode({ ...result, text });
     traverse(result.visitorKeys, result.ast, (path) => {
-      const type = path.node?.type;
-      // ember-estree 0.4.3 keeps Glimmer comment nodes in the template body,
-      // but comments are surfaced via ast.comments rather than as tokens.
-      if (type === 'GlimmerCommentStatement' || type === 'GlimmerMustacheCommentStatement') {
-        return;
-      }
       expect(source.getTokens(path.node)).not.toHaveLength(0);
     });
   });

--- a/tests/hbs-parser.test.js
+++ b/tests/hbs-parser.test.js
@@ -83,6 +83,12 @@ describe('hbs-parser', () => {
   it('all nodes have tokens', () => {
     const source = new SourceCode({ ...result, text });
     traverse(result.visitorKeys, result.ast, (path) => {
+      const type = path.node?.type;
+      // ember-estree 0.4.3 keeps Glimmer comment nodes in the template body,
+      // but comments are surfaced via ast.comments rather than as tokens.
+      if (type === 'GlimmerCommentStatement' || type === 'GlimmerMustacheCommentStatement') {
+        return;
+      }
       expect(source.getTokens(path.node)).not.toHaveLength(0);
     });
   });

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
 import { replaceExtensions } from '../src/parser/ts-patch.js';
 import { traverse } from '../src/parser/transforms.js';
-import { SourceCode } from 'eslint';
+import { Linter, SourceCode } from 'eslint';
 import { visitorKeys as tsVisitors } from '@typescript-eslint/visitor-keys';
 import { visitorKeys as glimmerVisitorKeys } from '@glimmer/syntax';
 
@@ -2438,6 +2438,98 @@ export const NotFound = <template>
     );
 
     expect(result.scopeManager.scopes[0].through.length).toBe(0);
+  });
+});
+
+describe('template comment nodes exposed as Program.comments', () => {
+  // Regression: ember-estree 0.4.3 (NullVoxPopuli/ember-estree#31) keeps Glimmer
+  // comment nodes inside the template body and stops mirroring them into
+  // Program.comments. ESLint's inline-config scanner only reads Program.comments,
+  // so `{{! eslint-disable-* }}` directives inside <template> get silently
+  // ignored. The parser is expected to promote template comment nodes back into
+  // Program.comments so directive handling keeps working.
+  it('promotes {{! … }} from inside <template> into Program.comments', () => {
+    const source = `const X = <template>
+  <li
+    {{! eslint-disable-next-line ember/template-no-unnecessary-concat }}
+    aria-current="{{foo}}"
+  ></li>
+</template>;`;
+    const result = parseForESLint(source, {
+      filePath: 'example.gts',
+      range: true,
+      loc: true,
+      comment: true,
+      tokens: true,
+    });
+    const directives = (result.ast.comments || []).filter(
+      (c) => c.value && /^\s*eslint-disable-next-line\s/.test(c.value)
+    );
+    expect(directives).toHaveLength(1);
+    expect(directives[0].value.trim()).toBe(
+      'eslint-disable-next-line ember/template-no-unnecessary-concat'
+    );
+  });
+
+  it('promotes {{!-- … --}} (long-form) from inside <template> into Program.comments', () => {
+    const source = `const X = <template>
+  <li
+    {{!-- eslint-disable-next-line ember/template-no-unnecessary-concat --}}
+    aria-current="{{foo}}"
+  ></li>
+</template>;`;
+    const result = parseForESLint(source, {
+      filePath: 'example.gts',
+      range: true,
+      loc: true,
+      comment: true,
+      tokens: true,
+    });
+    const directives = (result.ast.comments || []).filter(
+      (c) => c.value && /^\s*eslint-disable-next-line\s/.test(c.value)
+    );
+    expect(directives).toHaveLength(1);
+  });
+
+  it('ESLint honors {{! eslint-disable-next-line }} inside <template> (end-to-end)', () => {
+    const linter = new Linter();
+    linter.defineParser('ember-eslint-parser', { parseForESLint });
+    linter.defineRule('no-aria-current-concat', {
+      create(context) {
+        return {
+          GlimmerConcatStatement(node) {
+            context.report({ node, message: 'no concat' });
+          },
+        };
+      },
+    });
+
+    const withoutDirective = linter.verify(
+      `const X = <template><li aria-current="{{foo}}"></li></template>;`,
+      {
+        parser: 'ember-eslint-parser',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { 'no-aria-current-concat': 'error' },
+      },
+      { filename: 'example.gts' }
+    );
+    expect(withoutDirective.map((m) => m.ruleId)).toEqual(['no-aria-current-concat']);
+
+    const withDirective = linter.verify(
+      `const X = <template>
+  <li
+    {{! eslint-disable-next-line no-aria-current-concat }}
+    aria-current="{{foo}}"
+  ></li>
+</template>;`,
+      {
+        parser: 'ember-eslint-parser',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { 'no-aria-current-concat': 'error' },
+      },
+      { filename: 'example.gts' }
+    );
+    expect(withDirective.map((m) => m.ruleId)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
> This PR doesn't feel like the right path.  maybe the recent ember-estree-fix was too aggressive for the expectations of ember-eslint-parser?

Cowritten by claude

## Summary

- In `gjs-gts-parser`, walk each spliced Glimmer template subtree after parsing and append its `GlimmerCommentStatement` / `GlimmerMustacheCommentStatement` nodes to `result.ast.comments` so ESLint's inline-config scanner sees them.
- Bump `ember-estree` to `^0.4.3` so CI runs the fix against the regressed version.
- Adjust hbs-parser's `all nodes have tokens` test to skip Glimmer comment nodes — they're intentionally surfaced through `ast.comments`, not the token stream, after [ember-estree#31](https://github.com/NullVoxPopuli/ember-estree/pull/31).

## Why

[`NullVoxPopuli/ember-estree#31`](https://github.com/NullVoxPopuli/ember-estree/pull/31), shipped as `ember-estree@0.4.3`, kept Glimmer comment nodes inside `GlimmerTemplate.body` and stopped mirroring them into `Program.comments`. ESLint's inline-config scanner only reads `Program.comments` ([`getInlineConfigNodes`](https://github.com/eslint/eslint/blob/main/lib/languages/js/source-code/source-code.js)), so directives like `{{! eslint-disable-next-line ember/template-no-unnecessary-concat }}` placed inside a `<template>` block get silently dropped — the rule still fires.

The pure-hbs parser already populates `program.comments` explicitly; only the gjs/gts path was affected. This promotes the same information at the parser boundary so both paths behave consistently and ESLint directives keep working.

## Tests

- `tests/parser.test.js` — 3 new cases:
  - short-form `{{! … }}` directive appears in `Program.comments` (structural).
  - long-form `{{!-- … --}}` directive appears in `Program.comments` (structural).
  - End-to-end via `Linter`: the directive actually suppresses a custom rule inside `<template>`.
- `tests/hbs-parser.test.js` — `all nodes have tokens` now skips comment nodes (pre-existing regression from the `0.4.3` bump, independent of directive handling).

All tests pass locally against `ember-estree@0.4.3`.

## Follow-ups

After this ships, downstream ESLint plugins (e.g. `eslint-plugin-ember`) can keep using the default `ember-eslint-parser` without needing to pin `ember-estree@0.4.2`. I've opened a companion regression test in [`ember-cli/eslint-plugin-ember#2733`](https://github.com/ember-cli/eslint-plugin-ember/pull/2733) that will trip if this protection ever regresses again.