### PR TITLE
fix: sort program.comments by range in gjs-gts-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@glimmer/syntax": "^0.95.0",
     "@typescript-eslint/tsconfig-utils": "^8.57.1",
     "content-tag": "^4.1.1",
-    "ember-estree": "^0.6.0",
+    "ember-estree": "^0.6.1",
     "eslint-scope": "^9.1.2",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",
@@ -77,8 +77,7 @@
   },
   "pnpm": {
     "overrides": {
-      "ember-eslint-parser": "workspace:*",
-      "ember-estree": "link:../claude-make-estree-good/ember-estree"
+      "ember-eslint-parser": "workspace:*"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@glimmer/syntax": "^0.95.0",
     "@typescript-eslint/tsconfig-utils": "^8.57.1",
     "content-tag": "^4.1.1",
-    "ember-estree": "^0.4.2",
+    "ember-estree": "^0.6.0",
     "eslint-scope": "^9.1.2",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@glimmer/syntax": "^0.95.0",
     "@typescript-eslint/tsconfig-utils": "^8.57.1",
     "content-tag": "^4.1.1",
-    "ember-estree": "^0.6.1",
+    "ember-estree": "^0.6.2",
     "eslint-scope": "^9.1.2",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "pnpm": {
     "overrides": {
-      "ember-eslint-parser": "workspace:*"
+      "ember-eslint-parser": "workspace:*",
+      "ember-estree": "link:../claude-make-estree-good/ember-estree"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   ember-eslint-parser: workspace:*
+  ember-estree: link:../claude-make-estree-good/ember-estree
 
 importers:
 
@@ -21,8 +22,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-estree:
-        specifier: ^0.6.0
-        version: 0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: link:../claude-make-estree-good/ember-estree
+        version: link:../claude-make-estree-good/ember-estree
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
@@ -1094,15 +1095,6 @@ packages:
     resolution: {integrity: sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -1490,12 +1482,6 @@ packages:
     resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
     engines: {node: '>=14.18.0'}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
@@ -1588,128 +1574,6 @@ packages:
 
   '@octokit/types@14.1.0':
     resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
-
-  '@oxc-parser/binding-android-arm-eabi@0.119.0':
-    resolution: {integrity: sha512-e0ii/Tqwk5pAHZRY+ZyXOdKHNRNmE+dvTGQZ7xQ5XPH2Am59aktD30QvfcfwItGhNTLCj/5TYGH5RHvmvqaILQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.119.0':
-    resolution: {integrity: sha512-ha0xQpiStuoBv7HGazNKQWa6IRxri2+PpeojdAyBGnHGzfioA1GcStNGEGOyXvF+OxDfWvPuw5QiRYRUMtmgbQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.119.0':
-    resolution: {integrity: sha512-h/AIi5jfQz9WQUJJkkkHeXNYMhPtR72qnYZt0ZpM/LvlH/wpI5QkCPi7MWjjyY+m0JDorIXJyfOfccn8SbNSxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.119.0':
-    resolution: {integrity: sha512-15RwS/AawrgognvWsonI2eLKI5BqO0FzrpYXnzROysSR0x5RYsCc3UMFBwB1ph0UFFQzJy3ZbHHxfxp8RGr5Xg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.119.0':
-    resolution: {integrity: sha512-iKaayTIDqEj0yyNPL+0t/spNAxMv7O32uY4eu/ir8BvFNgavoRmN8uqxRj8sxQDle89N/1Iw0dgRjS3tiWrqlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
-    resolution: {integrity: sha512-PDoOaOx8YWoxy19WNeMs6kOE0uFSb5EtA64Ye0wSp6sQpe+l8Gd+yjX2L+yNwd5MpDOvOy8KToa2bqCV4pf6iQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
-    resolution: {integrity: sha512-AVxZ5Eo5squsUhpjnkCYuH20t5FCGV3HAP9UOKLxJQkmZW3kJvBGbfpH75ABxRrE2kGqmJW5FmS980u8v9Cepw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
-    resolution: {integrity: sha512-9vfdyT9gczSeSwsEkBHVjigI8SWo3iB9zxEzL+YMBUrN0ftCUkKQr27DaDZK4/cQ80t6KRB+g9sUmT2T2AGnOQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
-    resolution: {integrity: sha512-7BOq/tjSrtnp/ihw615uGcxMY3iya2qvVtwm15h2NvBZ6Jje+PC1GSUBOLfqGKJbUr9riSVV//a4iNhHI48Qdw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
-    resolution: {integrity: sha512-PQIrLJwoAaNyNSWBF+2SSgv44Jp+xpKVUA+8+PuoMhyBQ6lFSbQdaxewdn11i3heTFMYd2xF339HWax4S6MPVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
-    resolution: {integrity: sha512-spNh4YhT9K+Ya5hr6NmI1MazKSKORD8u5/06hFbzTslLnmmxiGaLqJXhNKIYUH39ne/JD5rkoRkUcOB2/LpC3A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
-    resolution: {integrity: sha512-hFoCTRxSJAcrNBYVlgNDDQq6LyJLYyhnJDlPtK/mWrPYS3x5/fUR9jc6wo5VyxKIL/0dDJBBWp19v81q9heU/A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
-    resolution: {integrity: sha512-bl7jHJZq3W5tYEvKG3yWZTUKTNb0/BtyYSnfMIrQ7t8hajCH4i1g0q+14s0KmQQl1UHxIX/Gx/Ps6e92qJQJmQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
-    resolution: {integrity: sha512-m+DE7NhJIEGp4efSJnNfRf3swT25rbZ1FTIihV+pOLTI+k5yNguxvqT338mNu61OVSx0BfpV8QlO2nz43GR/Zg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-musl@0.119.0':
-    resolution: {integrity: sha512-pHhnXZHUfd5pYzFLQfvx1DH2HY+L8DPZeh6SsQrsmoaODm1+j8VPeWLwGSrXQSz5f1kfT/mnzm1iNLVOGIeuaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-openharmony-arm64@0.119.0':
-    resolution: {integrity: sha512-8Fthv9nOec0hQLX16yjYyYIU+u8ZFuQojdQ3vNgXN+PcqI/bDohGgCATrxO69gLf0IzkyOmKmurXOQCYK8BYpQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.119.0':
-    resolution: {integrity: sha512-KpOU6fLqevFDP6ndkgE4BPoceELM4bOsEsAXjpe+FKYuUyEzHssYPBmxouGpXDQeAeWTBIjosw5yElLMRPuccw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
-    resolution: {integrity: sha512-omtTgAKIl6GQ40nG+wAWN8xMJLNtfmTdd0+wMIcrw1shX9y5TntAVIuiay3Du0wvUK9sgMpL07HYNphgHeZS0A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
-    resolution: {integrity: sha512-+0kqoCfv4WFP3e4BqcVEtf1moUuG9Zv5lo1aKcw1JakqJo008TGG+C2LnVM4QucGSZVQ/Ii/H5XCvrRbkeLQfA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
-    resolution: {integrity: sha512-5kaKmBHD+OQjZzGAQQ9n8jWNvCRxu3MjElAjkCqsS3i2wiN3hqHlOPKwGDydYiB1gKdeYGlTjRYtuF4gBLDSxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-project/types@0.119.0':
-    resolution: {integrity: sha512-9SCGhodOxEicD2kblitu34fGHcpmqgI3beYw/E22ehVLHzccHRFH91NmKt0MhZEaAwLpei6OOA9aB6Vuks9qAg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1852,9 +1716,6 @@ packages:
   '@tsconfig/ember@3.0.8':
     resolution: {integrity: sha512-OVnIsZIt/8q0VEtcdz3rRryNrm6gdJTxXlxefkGIrkZnME0wqslmwHlUEZ7mvh377df9FqBhNKrYNarhCW8zJA==}
     deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2852,9 +2713,6 @@ packages:
   ember-compatibility-helpers@1.2.7:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
-
-  ember-estree@0.6.0:
-    resolution: {integrity: sha512-MrbG11i5kvzTOnvRGMN9yUteDN2bNjIbC7JKbgkPjrl4wxQO3GWrwN60B2JDdtI5vA6y2EDtVv7vensmizsqYA==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -4354,10 +4212,6 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  oxc-parser@0.119.0:
-    resolution: {integrity: sha512-fNiKvO0ZHSUmINQlVY2It+vGbHxCvhpqJi0rZYFFOESoOy3fs5E4erKYGZtB/J1aULkjtY06aWNil4JxMsKXGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   p-finally@2.0.1:
     resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
     engines: {node: '>=8'}
@@ -5586,9 +5440,6 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  zimmerframe@1.1.4:
-    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
-
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
@@ -6643,22 +6494,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -7135,13 +6970,6 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -7261,73 +7089,6 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
-  '@oxc-parser/binding-android-arm-eabi@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-android-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
-    optional: true
-
-  '@oxc-project/types@0.119.0': {}
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7419,11 +7180,6 @@ snapshots:
   '@tootallnate/once@1.1.2': {}
 
   '@tsconfig/ember@3.0.8': {}
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/esrecurse@4.3.1': {}
 
@@ -8985,17 +8741,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  ember-estree@0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@glimmer/env': 0.1.7
-      '@glimmer/syntax': 0.95.0
-      content-tag: 4.1.1
-      oxc-parser: 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      zimmerframe: 1.1.4
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   ember-rfc176-data@0.3.18: {}
 
@@ -11125,34 +10870,6 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@oxc-project/types': 0.119.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.119.0
-      '@oxc-parser/binding-android-arm64': 0.119.0
-      '@oxc-parser/binding-darwin-arm64': 0.119.0
-      '@oxc-parser/binding-darwin-x64': 0.119.0
-      '@oxc-parser/binding-freebsd-x64': 0.119.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.119.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.119.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.119.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.119.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.119.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-x64-musl': 0.119.0
-      '@oxc-parser/binding-openharmony-arm64': 0.119.0
-      '@oxc-parser/binding-wasm32-wasi': 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-parser/binding-win32-arm64-msvc': 0.119.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.119.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.119.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   p-finally@2.0.1: {}
 
   p-limit@1.3.0:
@@ -12560,5 +12277,3 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
-
-  zimmerframe@1.1.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-estree:
-        specifier: ^0.6.1
-        version: 0.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.6.2
+        version: 0.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
@@ -2853,8 +2853,8 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-estree@0.6.1:
-    resolution: {integrity: sha512-lBntk6X39ubNXLga0PtxVaeRiRk9lUCRmbBgd8gF6uAYYA3tdNowGw2DLvnBmR4O1WlNj9s8omXbjSGO2kZJKw==}
+  ember-estree@0.6.2:
+    resolution: {integrity: sha512-CeKa6FZ95jp6de+vjhmv2XmOGBB2V95iiH7RqI2av1nU0m1XhFZEG8npoEciklQqPEzFO5OXS41b0mGvXBsJCA==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -5585,9 +5585,6 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
-
-  zimmerframe@1.1.4:
-    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
 
@@ -8986,13 +8983,12 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-estree@0.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  ember-estree@0.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/syntax': 0.95.0
       content-tag: 4.1.1
       oxc-parser: 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12560,5 +12556,3 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
-
-  zimmerframe@1.1.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   ember-eslint-parser: workspace:*
-  ember-estree: link:../claude-make-estree-good/ember-estree
 
 importers:
 
@@ -22,8 +21,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-estree:
-        specifier: link:../claude-make-estree-good/ember-estree
-        version: link:../claude-make-estree-good/ember-estree
+        specifier: ^0.6.1
+        version: 0.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
@@ -1095,6 +1094,15 @@ packages:
     resolution: {integrity: sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==}
     engines: {node: 12.* || 14.* || >= 16}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -1482,6 +1490,12 @@ packages:
     resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
     engines: {node: '>=14.18.0'}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
@@ -1574,6 +1588,128 @@ packages:
 
   '@octokit/types@14.1.0':
     resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@oxc-parser/binding-android-arm-eabi@0.119.0':
+    resolution: {integrity: sha512-e0ii/Tqwk5pAHZRY+ZyXOdKHNRNmE+dvTGQZ7xQ5XPH2Am59aktD30QvfcfwItGhNTLCj/5TYGH5RHvmvqaILQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.119.0':
+    resolution: {integrity: sha512-ha0xQpiStuoBv7HGazNKQWa6IRxri2+PpeojdAyBGnHGzfioA1GcStNGEGOyXvF+OxDfWvPuw5QiRYRUMtmgbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.119.0':
+    resolution: {integrity: sha512-h/AIi5jfQz9WQUJJkkkHeXNYMhPtR72qnYZt0ZpM/LvlH/wpI5QkCPi7MWjjyY+m0JDorIXJyfOfccn8SbNSxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.119.0':
+    resolution: {integrity: sha512-15RwS/AawrgognvWsonI2eLKI5BqO0FzrpYXnzROysSR0x5RYsCc3UMFBwB1ph0UFFQzJy3ZbHHxfxp8RGr5Xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.119.0':
+    resolution: {integrity: sha512-iKaayTIDqEj0yyNPL+0t/spNAxMv7O32uY4eu/ir8BvFNgavoRmN8uqxRj8sxQDle89N/1Iw0dgRjS3tiWrqlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
+    resolution: {integrity: sha512-PDoOaOx8YWoxy19WNeMs6kOE0uFSb5EtA64Ye0wSp6sQpe+l8Gd+yjX2L+yNwd5MpDOvOy8KToa2bqCV4pf6iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
+    resolution: {integrity: sha512-AVxZ5Eo5squsUhpjnkCYuH20t5FCGV3HAP9UOKLxJQkmZW3kJvBGbfpH75ABxRrE2kGqmJW5FmS980u8v9Cepw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
+    resolution: {integrity: sha512-9vfdyT9gczSeSwsEkBHVjigI8SWo3iB9zxEzL+YMBUrN0ftCUkKQr27DaDZK4/cQ80t6KRB+g9sUmT2T2AGnOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
+    resolution: {integrity: sha512-7BOq/tjSrtnp/ihw615uGcxMY3iya2qvVtwm15h2NvBZ6Jje+PC1GSUBOLfqGKJbUr9riSVV//a4iNhHI48Qdw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
+    resolution: {integrity: sha512-PQIrLJwoAaNyNSWBF+2SSgv44Jp+xpKVUA+8+PuoMhyBQ6lFSbQdaxewdn11i3heTFMYd2xF339HWax4S6MPVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
+    resolution: {integrity: sha512-spNh4YhT9K+Ya5hr6NmI1MazKSKORD8u5/06hFbzTslLnmmxiGaLqJXhNKIYUH39ne/JD5rkoRkUcOB2/LpC3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
+    resolution: {integrity: sha512-hFoCTRxSJAcrNBYVlgNDDQq6LyJLYyhnJDlPtK/mWrPYS3x5/fUR9jc6wo5VyxKIL/0dDJBBWp19v81q9heU/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
+    resolution: {integrity: sha512-bl7jHJZq3W5tYEvKG3yWZTUKTNb0/BtyYSnfMIrQ7t8hajCH4i1g0q+14s0KmQQl1UHxIX/Gx/Ps6e92qJQJmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
+    resolution: {integrity: sha512-m+DE7NhJIEGp4efSJnNfRf3swT25rbZ1FTIihV+pOLTI+k5yNguxvqT338mNu61OVSx0BfpV8QlO2nz43GR/Zg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.119.0':
+    resolution: {integrity: sha512-pHhnXZHUfd5pYzFLQfvx1DH2HY+L8DPZeh6SsQrsmoaODm1+j8VPeWLwGSrXQSz5f1kfT/mnzm1iNLVOGIeuaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.119.0':
+    resolution: {integrity: sha512-8Fthv9nOec0hQLX16yjYyYIU+u8ZFuQojdQ3vNgXN+PcqI/bDohGgCATrxO69gLf0IzkyOmKmurXOQCYK8BYpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.119.0':
+    resolution: {integrity: sha512-KpOU6fLqevFDP6ndkgE4BPoceELM4bOsEsAXjpe+FKYuUyEzHssYPBmxouGpXDQeAeWTBIjosw5yElLMRPuccw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
+    resolution: {integrity: sha512-omtTgAKIl6GQ40nG+wAWN8xMJLNtfmTdd0+wMIcrw1shX9y5TntAVIuiay3Du0wvUK9sgMpL07HYNphgHeZS0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
+    resolution: {integrity: sha512-+0kqoCfv4WFP3e4BqcVEtf1moUuG9Zv5lo1aKcw1JakqJo008TGG+C2LnVM4QucGSZVQ/Ii/H5XCvrRbkeLQfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
+    resolution: {integrity: sha512-5kaKmBHD+OQjZzGAQQ9n8jWNvCRxu3MjElAjkCqsS3i2wiN3hqHlOPKwGDydYiB1gKdeYGlTjRYtuF4gBLDSxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.119.0':
+    resolution: {integrity: sha512-9SCGhodOxEicD2kblitu34fGHcpmqgI3beYw/E22ehVLHzccHRFH91NmKt0MhZEaAwLpei6OOA9aB6Vuks9qAg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1716,6 +1852,9 @@ packages:
   '@tsconfig/ember@3.0.8':
     resolution: {integrity: sha512-OVnIsZIt/8q0VEtcdz3rRryNrm6gdJTxXlxefkGIrkZnME0wqslmwHlUEZ7mvh377df9FqBhNKrYNarhCW8zJA==}
     deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2713,6 +2852,9 @@ packages:
   ember-compatibility-helpers@1.2.7:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
+
+  ember-estree@0.6.1:
+    resolution: {integrity: sha512-lBntk6X39ubNXLga0PtxVaeRiRk9lUCRmbBgd8gF6uAYYA3tdNowGw2DLvnBmR4O1WlNj9s8omXbjSGO2kZJKw==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -4212,6 +4354,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxc-parser@0.119.0:
+    resolution: {integrity: sha512-fNiKvO0ZHSUmINQlVY2It+vGbHxCvhpqJi0rZYFFOESoOy3fs5E4erKYGZtB/J1aULkjtY06aWNil4JxMsKXGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   p-finally@2.0.1:
     resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
     engines: {node: '>=8'}
@@ -5440,6 +5586,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
@@ -6494,6 +6643,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -6970,6 +7135,13 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -7089,6 +7261,73 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
+  '@oxc-parser/binding-android-arm-eabi@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
+    optional: true
+
+  '@oxc-project/types@0.119.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7180,6 +7419,11 @@ snapshots:
   '@tootallnate/once@1.1.2': {}
 
   '@tsconfig/ember@3.0.8': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/esrecurse@4.3.1': {}
 
@@ -8741,6 +8985,17 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+
+  ember-estree@0.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/syntax': 0.95.0
+      content-tag: 4.1.1
+      oxc-parser: 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   ember-rfc176-data@0.3.18: {}
 
@@ -10870,6 +11125,34 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxc-parser@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@oxc-project/types': 0.119.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.119.0
+      '@oxc-parser/binding-android-arm64': 0.119.0
+      '@oxc-parser/binding-darwin-arm64': 0.119.0
+      '@oxc-parser/binding-darwin-x64': 0.119.0
+      '@oxc-parser/binding-freebsd-x64': 0.119.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.119.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.119.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.119.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.119.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.119.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-x64-musl': 0.119.0
+      '@oxc-parser/binding-openharmony-arm64': 0.119.0
+      '@oxc-parser/binding-wasm32-wasi': 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-parser/binding-win32-arm64-msvc': 0.119.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.119.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.119.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   p-finally@2.0.1: {}
 
   p-limit@1.3.0:
@@ -12277,3 +12560,5 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
+
+  zimmerframe@1.1.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-estree:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.6.0
+        version: 0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
@@ -1094,14 +1094,14 @@ packages:
     resolution: {integrity: sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1490,8 +1490,11 @@ packages:
     resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
     engines: {node: '>=14.18.0'}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -1848,6 +1851,7 @@ packages:
 
   '@tsconfig/ember@3.0.8':
     resolution: {integrity: sha512-OVnIsZIt/8q0VEtcdz3rRryNrm6gdJTxXlxefkGIrkZnME0wqslmwHlUEZ7mvh377df9FqBhNKrYNarhCW8zJA==}
+    deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2849,8 +2853,8 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-estree@0.4.2:
-    resolution: {integrity: sha512-Runf+IVY+hUhlk0QwwljhPYj0/kjza5CCRp/Hlfdk9MawKSxXQqR0WX4f2rChXAGbDIzK7JVopVaet5oIZr8tg==}
+  ember-estree@0.6.0:
+    resolution: {integrity: sha512-MrbG11i5kvzTOnvRGMN9yUteDN2bNjIbC7JKbgkPjrl4wxQO3GWrwN60B2JDdtI5vA6y2EDtVv7vensmizsqYA==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -6639,18 +6643,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7131,10 +7135,10 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -7305,9 +7309,12 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.119.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.119.0':
+  '@oxc-parser/binding-wasm32-wasi@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
@@ -8745,7 +8752,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8979,13 +8986,16 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-estree@0.4.2:
+  ember-estree@0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/syntax': 0.95.0
       content-tag: 4.1.1
-      oxc-parser: 0.119.0
+      oxc-parser: 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   ember-rfc176-data@0.3.18: {}
 
@@ -10982,7 +10992,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   node-releases@2.0.19: {}
 
@@ -11115,7 +11125,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.119.0:
+  oxc-parser@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.119.0
     optionalDependencies:
@@ -11135,10 +11145,13 @@ snapshots:
       '@oxc-parser/binding-linux-x64-gnu': 0.119.0
       '@oxc-parser/binding-linux-x64-musl': 0.119.0
       '@oxc-parser/binding-openharmony-arm64': 0.119.0
-      '@oxc-parser/binding-wasm32-wasi': 0.119.0
+      '@oxc-parser/binding-wasm32-wasi': 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-parser/binding-win32-arm64-msvc': 0.119.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.119.0
       '@oxc-parser/binding-win32-x64-msvc': 0.119.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   p-finally@2.0.1: {}
 

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -232,7 +232,7 @@ export function parseForESLint(code, options) {
             range: c.range,
             loc: c.loc,
           })),
-        ];
+        ].sort((a, b) => a.range[0] - b.range[0]);
       }
     }
 

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -161,12 +161,21 @@ export function parseForESLint(code, options) {
   const useTS = isTypescript || useTypescript;
 
   // Both paths create scopeManager inside the parser callback so it's
-  // available when toTree invokes visitors during splice — no second pass.
+  // available when toTree invokes the visitor factory — no second pass.
   let scopeManager = null;
+  const glimmerComments = [];
+  // Snapshot of range+type → TS-node mappings captured before zimmerframe's
+  // walk. zimmerframe's apply_mutations creates new ESTree node objects for any
+  // parent whose child was mutated (ClassDeclaration, ExportNamedDeclaration,
+  // Program). Those new objects are absent from the TS parser's WeakMap-based
+  // esTreeNodeToTSNodeMap, so TypeScript-aware rules crash. We restore the
+  // mapping for every new node by keying on range+type after the walk.
+  const prewalkTSMappings = new Map(); // "type,start,end" → tsNode
 
   try {
     const result = toTree(code, {
       filePath,
+      tokens: true,
       parser: useTS
         ? (placeholderJS) => {
             let parseCode = placeholderJS;
@@ -180,6 +189,33 @@ export function parseForESLint(code, options) {
               filePath,
             });
             scopeManager = tsResult.scopeManager;
+            // Snapshot the ESTree→TSNode mapping for every node in the
+            // original AST before zimmerframe's walk replaces some of them.
+            const esMap = tsResult.services?.esTreeNodeToTSNodeMap;
+            if (esMap) {
+              const snapSeen = new WeakSet();
+              (function snap(node) {
+                if (!node || typeof node !== 'object' || snapSeen.has(node)) return;
+                if (Array.isArray(node)) {
+                  node.forEach(snap);
+                  return;
+                }
+                if (
+                  typeof node.type !== 'string' ||
+                  !Array.isArray(node.range) ||
+                  typeof node.range[0] !== 'number'
+                )
+                  return;
+                snapSeen.add(node);
+                const tsNode = esMap.get(node);
+                if (tsNode)
+                  prewalkTSMappings.set(`${node.type},${node.range[0]},${node.range[1]}`, tsNode);
+                for (const key of Object.keys(node)) {
+                  if (key === 'parent' || key === 'tokens' || key === 'comments') continue;
+                  snap(node[key]);
+                }
+              })(tsResult.ast);
+            }
             return tsResult;
           }
         : (placeholderJS) => {
@@ -196,10 +232,174 @@ export function parseForESLint(code, options) {
             });
             return { ast: program, scopeManager };
           },
-      visitors: buildGlimmerVisitors(() => scopeManager, useTS),
+      // Factory form: scopeManager is set by the parser callback before this runs.
+      // Returns null when unavailable so ember-estree skips the zimmerframe walk.
+      // Also collect Glimmer comment nodes for surfacing in program.comments.
+      visitors: (_outerAst) => {
+        const v = buildGlimmerVisitors(scopeManager, useTS);
+        if (!v) return null;
+        return {
+          ...v,
+          GlimmerMustacheCommentStatement(node) {
+            glimmerComments.push(node);
+          },
+          GlimmerCommentStatement(node) {
+            glimmerComments.push(node);
+          },
+        };
+      },
     });
 
     if (!result.scopeManager) result.scopeManager = scopeManager;
+
+    // zimmerframe replaces parent nodes (ClassDeclaration, ExportNamedDeclaration,
+    // Program) with new objects when a child is mutated. The TS scope manager
+    // holds references to the ORIGINAL nodes, which are orphaned — ESLint only
+    // sets .parent on the new objects it traverses, so original nodes remain
+    // parentless and rules like no-unused-vars crash on node.parent.type.
+    // Fix by building a range+type → parent map from the new AST and patching
+    // any scope definition node whose .parent is still missing.
+    const parentByKey = new Map();
+    if (result.scopeManager) {
+      const astRoot = result.ast?.program ?? result.ast;
+      if (astRoot) {
+        // Only traverse nodes that look like ESTree (have a string type and an
+        // array range). Skipping TypeScript-internal properties (heritageClauses,
+        // implements, etc.) avoids traversing into TS-internal structures that
+        // can form cycles or have unexpected shapes.
+        const seen = new WeakSet();
+        (function collectParents(node, parent) {
+          if (!node || typeof node !== 'object' || seen.has(node)) return;
+          if (Array.isArray(node)) {
+            node.forEach((c) => collectParents(c, parent));
+            return;
+          }
+          // Only process ESTree-shaped nodes (string type + [start,end] range)
+          if (
+            typeof node.type !== 'string' ||
+            !Array.isArray(node.range) ||
+            typeof node.range[0] !== 'number'
+          ) {
+            return;
+          }
+          seen.add(node);
+          parentByKey.set(`${node.type},${node.range[0]},${node.range[1]}`, parent);
+          for (const key of Object.keys(node)) {
+            if (key === 'parent' || key === 'tokens' || key === 'comments') continue;
+            collectParents(node[key], node);
+          }
+        })(astRoot, null);
+
+        (function fixScope(scope) {
+          for (const variable of scope.variables) {
+            for (const def of variable.defs) {
+              if (def.node && !def.node.parent && def.node.range) {
+                const key = `${def.node.type},${def.node.range[0]},${def.node.range[1]}`;
+                const newParent = parentByKey.get(key);
+                if (newParent) def.node.parent = newParent;
+              }
+            }
+          }
+          for (const child of scope.childScopes) fixScope(child);
+        })(result.scopeManager.globalScope ?? result.scopeManager.scopes?.[0]);
+      }
+    }
+
+    // Restore TS service map entries for nodes replaced by zimmerframe.
+    // zimmerframe's apply_mutations creates new ESTree node objects for any
+    // parent whose child was mutated. The TS parser's WeakMap-based
+    // esTreeNodeToTSNodeMap only knows the ORIGINAL nodes — TypeScript-aware
+    // rules crash when esMap.get(newNode) → undefined.
+    //
+    // Strategy: restore mappings for (a) scope def nodes and their parents, and
+    // (b) GlimmerTemplate nodes (mapped to the placeholder tsNode so
+    // getTypeAtLocation returns `string` rather than the error intrinsic).
+    // We avoid walking the full new AST with Object.keys, which traverses
+    // TypeScript-internal properties and causes crashes in unrelated rules.
+    if (prewalkTSMappings.size > 0 && result.services?.esTreeNodeToTSNodeMap) {
+      const esMap = result.services.esTreeNodeToTSNodeMap;
+      const PLACEHOLDER_TYPES = [
+        'TemplateLiteral',
+        'StaticBlock',
+        'ExpressionStatement',
+        'ExportDefaultDeclaration',
+      ];
+      function restoreNode(n) {
+        if (!n || esMap.has(n) || !n.range) return;
+        const tsNode = prewalkTSMappings.get(`${n.type},${n.range[0]},${n.range[1]}`);
+        if (tsNode) esMap.set(n, tsNode);
+      }
+      function restoreGlimmerTemplate(n) {
+        if (!n || n.type !== 'GlimmerTemplate' || esMap.has(n) || !n.range) return;
+        for (const pt of PLACEHOLDER_TYPES) {
+          const tsNode = prewalkTSMappings.get(`${pt},${n.range[0]},${n.range[1]}`);
+          if (tsNode) {
+            esMap.set(n, tsNode);
+            break;
+          }
+        }
+      }
+      (function restoreScopeDefs(scope) {
+        for (const variable of scope.variables) {
+          for (const def of variable.defs) {
+            restoreNode(def.node);
+            if (!def.node?.range) continue;
+            const defKey = `${def.node.type},${def.node.range[0]},${def.node.range[1]}`;
+            const parentNode = parentByKey.get(defKey);
+            // Restore the parent node (e.g. VariableDeclaration for
+            // VariableDeclarator, ExportNamedDeclaration for ClassDeclaration)
+            // since TypeScript rules visit those types too.
+            restoreNode(parentNode);
+            // Find the NEW version of def.node in the new AST (def.node is the
+            // ORIGINAL from the scope manager, already in esMap, so restoreNode
+            // skipped it). The new node has the same range but different identity.
+            // Restore it so rules that visit the new AST node can look up tsNode.
+            // Find the NEW version of def.node (same range+type, new identity)
+            // inside the parent. Covers both array containers (.declarations,
+            // .body.body) and singular containers (.declaration for export nodes).
+            let newDefNode = null;
+            if (parentNode) {
+              const key = def.node.range[0];
+              const type = def.node.type;
+              if (
+                parentNode.declaration?.type === type &&
+                parentNode.declaration?.range?.[0] === key
+              ) {
+                newDefNode = parentNode.declaration;
+              } else {
+                const arr = parentNode.declarations ?? parentNode.body?.body ?? [];
+                if (Array.isArray(arr)) {
+                  newDefNode = arr.find((n) => n?.range?.[0] === key && n.type === type) ?? null;
+                }
+              }
+            }
+            restoreNode(newDefNode);
+            // Restore GlimmerTemplate children so getTypeAtLocation returns the
+            // placeholder type (string) not the error intrinsic.
+            restoreGlimmerTemplate(newDefNode?.init);
+            restoreGlimmerTemplate(newDefNode?.body);
+          }
+        }
+        for (const child of scope.childScopes) restoreScopeDefs(child);
+      })(result.scopeManager?.globalScope ?? result.scopeManager?.scopes?.[0]);
+    }
+
+    // Surface Glimmer template comments in program.comments as type:'Block'
+    // so ESLint's inline-config scanner and plugin rules recognise them.
+    if (glimmerComments.length > 0) {
+      const programNode = result.ast?.program ?? result.ast;
+      if (programNode) {
+        programNode.comments = [
+          ...(programNode.comments || []),
+          ...glimmerComments.map((c) => ({
+            type: 'Block',
+            value: c.value,
+            range: c.range,
+            loc: c.loc,
+          })),
+        ];
+      }
+    }
 
     if (result.services?.program) {
       const programAllowJs = result.services.program.getCompilerOptions?.()?.allowJs;
@@ -231,7 +431,21 @@ export function parseForESLint(code, options) {
         .split(':')
         .slice(-2)
         .map((x) => parseInt(x));
-      const err = new Error(e.source_code || e.message);
+      // e.source_code is a multi-line diagnostic block — extract just the
+      // first non-empty line so ESLint's single-line message format is preserved.
+      // Strip ANSI escape codes defensively (e.source_code may be coloured in
+      // TTY environments, which breaks grep-based test:check assertions).
+      // eslint-disable-next-line no-control-regex
+      const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+      const errorText = e.source_code
+        ? stripAnsi(
+            e.source_code
+              .split('\n')
+              .map((l) => l.trim())
+              .find((l) => l.length > 0) ?? e.message
+          )
+        : e.message;
+      const err = new Error(errorText);
       err.lineNumber = line;
       err.column = column;
       err.fileName = filePath;

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -128,6 +128,34 @@ function getAllowJs(options) {
   return false;
 }
 
+// Placeholder node types produced by toPlaceholderJS (backtick / static-block).
+const PLACEHOLDER_TYPES = new Set([
+  'TemplateLiteral',
+  'StaticBlock',
+  'ExpressionStatement',
+  'ExportDefaultDeclaration',
+]);
+
+function snapshotPlaceholders(root, outMap) {
+  const seen = new WeakSet();
+  (function walk(node) {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (typeof node.type !== 'string') return;
+    seen.add(node);
+    if (PLACEHOLDER_TYPES.has(node.type) && node.range) {
+      outMap.set(node.range[0], node);
+    }
+    for (const k of Object.keys(node)) {
+      if (k === 'parent' || k === 'tokens' || k === 'comments') continue;
+      walk(node[k]);
+    }
+  })(root);
+}
+
 /**
  * @type {import('eslint').ParserModule}
  */
@@ -164,13 +192,11 @@ export function parseForESLint(code, options) {
   // available when toTree invokes the visitor factory — no second pass.
   let scopeManager = null;
   const glimmerComments = [];
-  // Snapshot of range+type → TS-node mappings captured before zimmerframe's
-  // walk. zimmerframe's apply_mutations creates new ESTree node objects for any
-  // parent whose child was mutated (ClassDeclaration, ExportNamedDeclaration,
-  // Program). Those new objects are absent from the TS parser's WeakMap-based
-  // esTreeNodeToTSNodeMap, so TypeScript-aware rules crash. We restore the
-  // mapping for every new node by keying on range+type after the walk.
-  const prewalkTSMappings = new Map(); // "type,start,end" → tsNode
+  // Placeholder AST nodes keyed by range start, captured before the splice
+  // so we can forward each placeholder's tsNode to the GlimmerTemplate that
+  // replaces it. Typed rules call `getTypeAtLocation(glimmerTemplate)`;
+  // without this forwarding they'd hit the TS error intrinsic.
+  const placeholderByStart = new Map();
 
   try {
     const result = toTree(code, {
@@ -189,33 +215,6 @@ export function parseForESLint(code, options) {
               filePath,
             });
             scopeManager = tsResult.scopeManager;
-            // Snapshot the ESTree→TSNode mapping for every node in the
-            // original AST before zimmerframe's walk replaces some of them.
-            const esMap = tsResult.services?.esTreeNodeToTSNodeMap;
-            if (esMap) {
-              const snapSeen = new WeakSet();
-              (function snap(node) {
-                if (!node || typeof node !== 'object' || snapSeen.has(node)) return;
-                if (Array.isArray(node)) {
-                  node.forEach(snap);
-                  return;
-                }
-                if (
-                  typeof node.type !== 'string' ||
-                  !Array.isArray(node.range) ||
-                  typeof node.range[0] !== 'number'
-                )
-                  return;
-                snapSeen.add(node);
-                const tsNode = esMap.get(node);
-                if (tsNode)
-                  prewalkTSMappings.set(`${node.type},${node.range[0]},${node.range[1]}`, tsNode);
-                for (const key of Object.keys(node)) {
-                  if (key === 'parent' || key === 'tokens' || key === 'comments') continue;
-                  snap(node[key]);
-                }
-              })(tsResult.ast);
-            }
             return tsResult;
           }
         : (placeholderJS) => {
@@ -232,12 +231,14 @@ export function parseForESLint(code, options) {
             });
             return { ast: program, scopeManager };
           },
-      // Factory form: scopeManager is set by the parser callback before this runs.
-      // Returns null when unavailable so ember-estree skips the zimmerframe walk.
-      // Also collect Glimmer comment nodes for surfacing in program.comments.
-      visitors: (_outerAst) => {
+      // Factory form: scopeManager is set by the parser callback before this
+      // runs. Returns null when unavailable so ember-estree skips the walk.
+      // Before the splice happens we also snapshot the placeholder nodes so
+      // we can forward their tsNode to the GlimmerTemplate that replaces them.
+      visitors: (outerAst) => {
         const v = buildGlimmerVisitors(scopeManager, useTS);
         if (!v) return null;
+        if (outerAst) snapshotPlaceholders(outerAst, placeholderByStart);
         return {
           ...v,
           GlimmerMustacheCommentStatement(node) {
@@ -252,118 +253,17 @@ export function parseForESLint(code, options) {
 
     if (!result.scopeManager) result.scopeManager = scopeManager;
 
-    // zimmerframe replaces parent nodes (ClassDeclaration, ExportNamedDeclaration,
-    // VariableDeclaration, Program) with new objects when a child is mutated.
-    // The scope manager's WeakMap holds references to the ORIGINAL nodes, so
-    // ESLint's context.getScope() fails on the new nodes and falls through to
-    // the global scope — crashing rules (e.g. no-setter-return) that access
-    // `scope.upper.type` on the global scope's null upper.
-    // Fix by building a range+type → node map of the new AST and re-registering
-    // every scope's block on the new node + patching orphan def.node.parent.
-    const parentByKey = new Map();
-    const nodeByKey = new Map();
-    if (result.scopeManager) {
-      const astRoot = result.ast?.program ?? result.ast;
-      if (astRoot) {
-        // Only traverse nodes that look like ESTree (have a string type and an
-        // array range). Skipping TypeScript-internal properties (heritageClauses,
-        // implements, etc.) avoids traversing into TS-internal structures that
-        // can form cycles or have unexpected shapes.
-        const seen = new WeakSet();
-        (function collectParents(node, parent) {
-          if (!node || typeof node !== 'object' || seen.has(node)) return;
-          if (Array.isArray(node)) {
-            node.forEach((c) => collectParents(c, parent));
-            return;
-          }
-          // Only process ESTree-shaped nodes (string type + [start,end] range)
-          if (
-            typeof node.type !== 'string' ||
-            !Array.isArray(node.range) ||
-            typeof node.range[0] !== 'number'
-          ) {
-            return;
-          }
-          seen.add(node);
-          const key = `${node.type},${node.range[0]},${node.range[1]}`;
-          parentByKey.set(key, parent);
-          nodeByKey.set(key, node);
-          for (const k of Object.keys(node)) {
-            if (k === 'parent' || k === 'tokens' || k === 'comments') continue;
-            collectParents(node[k], node);
-          }
-        })(astRoot, null);
-
-        // Re-point scope.block to the new AST node and re-register the
-        // WeakMap entries (both eslint-scope's `__nodeToScope` and
-        // typescript-eslint's `nodeToScope`). Without this, ESLint can't
-        // find a scope for a function/arrow/class replaced by zimmerframe
-        // and falls back to the global scope.
-        const sm = result.scopeManager;
-        const nodeToScope = sm.__nodeToScope ?? sm.nodeToScope;
-        const declaredVars = sm.__declaredVariables ?? sm.declaredVariables;
-        for (const scope of sm.scopes || []) {
-          const oldBlock = scope.block;
-          if (!oldBlock || !oldBlock.range) continue;
-          const key = `${oldBlock.type},${oldBlock.range[0]},${oldBlock.range[1]}`;
-          const newBlock = nodeByKey.get(key);
-          if (!newBlock || newBlock === oldBlock) continue;
-          if (nodeToScope) {
-            const entry = nodeToScope.get(oldBlock);
-            if (entry) nodeToScope.set(newBlock, entry);
-          }
-          if (declaredVars?.has?.(oldBlock)) {
-            declaredVars.set(newBlock, declaredVars.get(oldBlock));
-          }
-          scope.block = newBlock;
-        }
-
-        (function fixScope(scope) {
-          for (const variable of scope.variables) {
-            for (const def of variable.defs) {
-              if (def.node && !def.node.parent && def.node.range) {
-                const key = `${def.node.type},${def.node.range[0]},${def.node.range[1]}`;
-                const newParent = parentByKey.get(key);
-                if (newParent) def.node.parent = newParent;
-              }
-            }
-          }
-          for (const child of scope.childScopes) fixScope(child);
-        })(result.scopeManager.globalScope ?? result.scopeManager.scopes?.[0]);
-      }
-    }
-
-    // Restore TS service map entries for nodes replaced by zimmerframe.
-    // zimmerframe's apply_mutations creates new ESTree node objects for any
-    // parent whose child was mutated. The TS parser's WeakMap-based
-    // esTreeNodeToTSNodeMap only knows the ORIGINAL nodes — TypeScript-aware
-    // rules crash when esMap.get(newNode) → undefined.
-    //
-    // For every new ESTree node, if a pre-walk mapping exists with the same
-    // type+range, copy it forward. Also map GlimmerTemplate → placeholder
-    // tsNode so getTypeAtLocation returns `string` (not the error intrinsic).
-    if (prewalkTSMappings.size > 0 && result.services?.esTreeNodeToTSNodeMap) {
-      const esMap = result.services.esTreeNodeToTSNodeMap;
-      const PLACEHOLDER_TYPES = [
-        'TemplateLiteral',
-        'StaticBlock',
-        'ExpressionStatement',
-        'ExportDefaultDeclaration',
-      ];
-      for (const [key, node] of nodeByKey) {
-        if (esMap.has(node)) continue;
-        if (node.type === 'GlimmerTemplate') {
-          for (const pt of PLACEHOLDER_TYPES) {
-            const tsNode = prewalkTSMappings.get(`${pt},${node.range[0]},${node.range[1]}`);
-            if (tsNode) {
-              esMap.set(node, tsNode);
-              break;
-            }
-          }
-          continue;
-        }
-        const tsNode = prewalkTSMappings.get(key);
-        if (tsNode) esMap.set(node, tsNode);
+    // Forward each placeholder's tsNode onto its GlimmerTemplate replacement,
+    // so typed rules calling `getTypeAtLocation(glimmerTemplate)` see the
+    // placeholder's type (string for expression templates, void for class-
+    // member static blocks) instead of the TS error intrinsic.
+    const esMap = result.services?.esTreeNodeToTSNodeMap;
+    if (esMap && result.templateInfos) {
+      for (const ti of result.templateInfos) {
+        const start = ti.utf16Range?.[0] ?? ti.ast?.range?.[0];
+        const placeholder = placeholderByStart.get(start);
+        const placeholderTS = placeholder && esMap.get(placeholder);
+        if (placeholderTS && !esMap.has(ti.ast)) esMap.set(ti.ast, placeholderTS);
       }
     }
 

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -339,11 +339,9 @@ export function parseForESLint(code, options) {
     // esTreeNodeToTSNodeMap only knows the ORIGINAL nodes — TypeScript-aware
     // rules crash when esMap.get(newNode) → undefined.
     //
-    // Strategy: restore mappings for (a) scope def nodes and their parents, and
-    // (b) GlimmerTemplate nodes (mapped to the placeholder tsNode so
-    // getTypeAtLocation returns `string` rather than the error intrinsic).
-    // We avoid walking the full new AST with Object.keys, which traverses
-    // TypeScript-internal properties and causes crashes in unrelated rules.
+    // For every new ESTree node, if a pre-walk mapping exists with the same
+    // type+range, copy it forward. Also map GlimmerTemplate → placeholder
+    // tsNode so getTypeAtLocation returns `string` (not the error intrinsic).
     if (prewalkTSMappings.size > 0 && result.services?.esTreeNodeToTSNodeMap) {
       const esMap = result.services.esTreeNodeToTSNodeMap;
       const PLACEHOLDER_TYPES = [
@@ -352,64 +350,21 @@ export function parseForESLint(code, options) {
         'ExpressionStatement',
         'ExportDefaultDeclaration',
       ];
-      function restoreNode(n) {
-        if (!n || esMap.has(n) || !n.range) return;
-        const tsNode = prewalkTSMappings.get(`${n.type},${n.range[0]},${n.range[1]}`);
-        if (tsNode) esMap.set(n, tsNode);
-      }
-      function restoreGlimmerTemplate(n) {
-        if (!n || n.type !== 'GlimmerTemplate' || esMap.has(n) || !n.range) return;
-        for (const pt of PLACEHOLDER_TYPES) {
-          const tsNode = prewalkTSMappings.get(`${pt},${n.range[0]},${n.range[1]}`);
-          if (tsNode) {
-            esMap.set(n, tsNode);
-            break;
-          }
-        }
-      }
-      (function restoreScopeDefs(scope) {
-        for (const variable of scope.variables) {
-          for (const def of variable.defs) {
-            restoreNode(def.node);
-            if (!def.node?.range) continue;
-            const defKey = `${def.node.type},${def.node.range[0]},${def.node.range[1]}`;
-            const parentNode = parentByKey.get(defKey);
-            // Restore the parent node (e.g. VariableDeclaration for
-            // VariableDeclarator, ExportNamedDeclaration for ClassDeclaration)
-            // since TypeScript rules visit those types too.
-            restoreNode(parentNode);
-            // Find the NEW version of def.node in the new AST (def.node is the
-            // ORIGINAL from the scope manager, already in esMap, so restoreNode
-            // skipped it). The new node has the same range but different identity.
-            // Restore it so rules that visit the new AST node can look up tsNode.
-            // Find the NEW version of def.node (same range+type, new identity)
-            // inside the parent. Covers both array containers (.declarations,
-            // .body.body) and singular containers (.declaration for export nodes).
-            let newDefNode = null;
-            if (parentNode) {
-              const key = def.node.range[0];
-              const type = def.node.type;
-              if (
-                parentNode.declaration?.type === type &&
-                parentNode.declaration?.range?.[0] === key
-              ) {
-                newDefNode = parentNode.declaration;
-              } else {
-                const arr = parentNode.declarations ?? parentNode.body?.body ?? [];
-                if (Array.isArray(arr)) {
-                  newDefNode = arr.find((n) => n?.range?.[0] === key && n.type === type) ?? null;
-                }
-              }
+      for (const [key, node] of nodeByKey) {
+        if (esMap.has(node)) continue;
+        if (node.type === 'GlimmerTemplate') {
+          for (const pt of PLACEHOLDER_TYPES) {
+            const tsNode = prewalkTSMappings.get(`${pt},${node.range[0]},${node.range[1]}`);
+            if (tsNode) {
+              esMap.set(node, tsNode);
+              break;
             }
-            restoreNode(newDefNode);
-            // Restore GlimmerTemplate children so getTypeAtLocation returns the
-            // placeholder type (string) not the error intrinsic.
-            restoreGlimmerTemplate(newDefNode?.init);
-            restoreGlimmerTemplate(newDefNode?.body);
           }
+          continue;
         }
-        for (const child of scope.childScopes) restoreScopeDefs(child);
-      })(result.scopeManager?.globalScope ?? result.scopeManager?.scopes?.[0]);
+        const tsNode = prewalkTSMappings.get(key);
+        if (tsNode) esMap.set(node, tsNode);
+      }
     }
 
     // Surface Glimmer template comments in program.comments as type:'Block'

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -128,34 +128,6 @@ function getAllowJs(options) {
   return false;
 }
 
-// Placeholder node types produced by toPlaceholderJS (backtick / static-block).
-const PLACEHOLDER_TYPES = new Set([
-  'TemplateLiteral',
-  'StaticBlock',
-  'ExpressionStatement',
-  'ExportDefaultDeclaration',
-]);
-
-function snapshotPlaceholders(root, outMap) {
-  const seen = new WeakSet();
-  (function walk(node) {
-    if (!node || typeof node !== 'object' || seen.has(node)) return;
-    if (Array.isArray(node)) {
-      node.forEach(walk);
-      return;
-    }
-    if (typeof node.type !== 'string') return;
-    seen.add(node);
-    if (PLACEHOLDER_TYPES.has(node.type) && node.range) {
-      outMap.set(node.range[0], node);
-    }
-    for (const k of Object.keys(node)) {
-      if (k === 'parent' || k === 'tokens' || k === 'comments') continue;
-      walk(node[k]);
-    }
-  })(root);
-}
-
 /**
  * @type {import('eslint').ParserModule}
  */
@@ -192,11 +164,6 @@ export function parseForESLint(code, options) {
   // available when toTree invokes the visitor factory — no second pass.
   let scopeManager = null;
   const glimmerComments = [];
-  // Placeholder AST nodes keyed by range start, captured before the splice
-  // so we can forward each placeholder's tsNode to the GlimmerTemplate that
-  // replaces it. Typed rules call `getTypeAtLocation(glimmerTemplate)`;
-  // without this forwarding they'd hit the TS error intrinsic.
-  const placeholderByStart = new Map();
 
   try {
     const result = toTree(code, {
@@ -233,12 +200,9 @@ export function parseForESLint(code, options) {
           },
       // Factory form: scopeManager is set by the parser callback before this
       // runs. Returns null when unavailable so ember-estree skips the walk.
-      // Before the splice happens we also snapshot the placeholder nodes so
-      // we can forward their tsNode to the GlimmerTemplate that replaces them.
-      visitors: (outerAst) => {
+      visitors: () => {
         const v = buildGlimmerVisitors(scopeManager, useTS);
         if (!v) return null;
-        if (outerAst) snapshotPlaceholders(outerAst, placeholderByStart);
         return {
           ...v,
           GlimmerMustacheCommentStatement(node) {
@@ -260,10 +224,8 @@ export function parseForESLint(code, options) {
     const esMap = result.services?.esTreeNodeToTSNodeMap;
     if (esMap && result.templateInfos) {
       for (const ti of result.templateInfos) {
-        const start = ti.utf16Range?.[0] ?? ti.ast?.range?.[0];
-        const placeholder = placeholderByStart.get(start);
-        const placeholderTS = placeholder && esMap.get(placeholder);
-        if (placeholderTS && !esMap.has(ti.ast)) esMap.set(ti.ast, placeholderTS);
+        const ts = esMap.get(ti.placeholder);
+        if (ts && !esMap.has(ti.ast)) esMap.set(ti.ast, ts);
       }
     }
 

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -414,20 +414,13 @@ export function parseForESLint(code, options) {
         .split(':')
         .slice(-2)
         .map((x) => parseInt(x));
-      // e.source_code is a multi-line diagnostic block — extract just the
-      // first non-empty line so ESLint's single-line message format is preserved.
-      // Strip ANSI escape codes defensively (e.source_code may be coloured in
-      // TTY environments, which breaks grep-based test:check assertions).
+      // e.source_code is the full diagnostic block. Strip ANSI escape codes
+      // (content-tag colours output in TTY environments, which breaks
+      // grep-based test:check assertions) and trim leading/trailing blank
+      // lines so consumers see a clean message.
       // eslint-disable-next-line no-control-regex
       const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
-      const errorText = e.source_code
-        ? stripAnsi(
-            e.source_code
-              .split('\n')
-              .map((l) => l.trim())
-              .find((l) => l.length > 0) ?? e.message
-          )
-        : e.message;
+      const errorText = e.source_code ? stripAnsi(e.source_code).trim() : e.message;
       const err = new Error(errorText);
       err.lineNumber = line;
       err.column = column;

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -200,19 +200,9 @@ export function parseForESLint(code, options) {
           },
       // Factory form: scopeManager is set by the parser callback before this
       // runs. Returns null when unavailable so ember-estree skips the walk.
-      visitors: () => {
-        const v = buildGlimmerVisitors(scopeManager, useTS);
-        if (!v) return null;
-        return {
-          ...v,
-          GlimmerMustacheCommentStatement(node) {
-            glimmerComments.push(node);
-          },
-          GlimmerCommentStatement(node) {
-            glimmerComments.push(node);
-          },
-        };
-      },
+      // The comments array is passed through so comment handlers share a
+      // single closure over it.
+      visitors: () => buildGlimmerVisitors(scopeManager, useTS, glimmerComments),
     });
 
     if (!result.scopeManager) result.scopeManager = scopeManager;

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -253,13 +253,15 @@ export function parseForESLint(code, options) {
     if (!result.scopeManager) result.scopeManager = scopeManager;
 
     // zimmerframe replaces parent nodes (ClassDeclaration, ExportNamedDeclaration,
-    // Program) with new objects when a child is mutated. The TS scope manager
-    // holds references to the ORIGINAL nodes, which are orphaned — ESLint only
-    // sets .parent on the new objects it traverses, so original nodes remain
-    // parentless and rules like no-unused-vars crash on node.parent.type.
-    // Fix by building a range+type → parent map from the new AST and patching
-    // any scope definition node whose .parent is still missing.
+    // VariableDeclaration, Program) with new objects when a child is mutated.
+    // The scope manager's WeakMap holds references to the ORIGINAL nodes, so
+    // ESLint's context.getScope() fails on the new nodes and falls through to
+    // the global scope — crashing rules (e.g. no-setter-return) that access
+    // `scope.upper.type` on the global scope's null upper.
+    // Fix by building a range+type → node map of the new AST and re-registering
+    // every scope's block on the new node + patching orphan def.node.parent.
     const parentByKey = new Map();
+    const nodeByKey = new Map();
     if (result.scopeManager) {
       const astRoot = result.ast?.program ?? result.ast;
       if (astRoot) {
@@ -283,12 +285,38 @@ export function parseForESLint(code, options) {
             return;
           }
           seen.add(node);
-          parentByKey.set(`${node.type},${node.range[0]},${node.range[1]}`, parent);
-          for (const key of Object.keys(node)) {
-            if (key === 'parent' || key === 'tokens' || key === 'comments') continue;
-            collectParents(node[key], node);
+          const key = `${node.type},${node.range[0]},${node.range[1]}`;
+          parentByKey.set(key, parent);
+          nodeByKey.set(key, node);
+          for (const k of Object.keys(node)) {
+            if (k === 'parent' || k === 'tokens' || k === 'comments') continue;
+            collectParents(node[k], node);
           }
         })(astRoot, null);
+
+        // Re-point scope.block to the new AST node and re-register the
+        // WeakMap entries (both eslint-scope's `__nodeToScope` and
+        // typescript-eslint's `nodeToScope`). Without this, ESLint can't
+        // find a scope for a function/arrow/class replaced by zimmerframe
+        // and falls back to the global scope.
+        const sm = result.scopeManager;
+        const nodeToScope = sm.__nodeToScope ?? sm.nodeToScope;
+        const declaredVars = sm.__declaredVariables ?? sm.declaredVariables;
+        for (const scope of sm.scopes || []) {
+          const oldBlock = scope.block;
+          if (!oldBlock || !oldBlock.range) continue;
+          const key = `${oldBlock.type},${oldBlock.range[0]},${oldBlock.range[1]}`;
+          const newBlock = nodeByKey.get(key);
+          if (!newBlock || newBlock === oldBlock) continue;
+          if (nodeToScope) {
+            const entry = nodeToScope.get(oldBlock);
+            if (entry) nodeToScope.set(newBlock, entry);
+          }
+          if (declaredVars?.has?.(oldBlock)) {
+            declaredVars.set(newBlock, declaredVars.get(oldBlock));
+          }
+          scope.block = newBlock;
+        }
 
         (function fixScope(scope) {
           for (const variable of scope.variables) {

--- a/src/parser/hbs-parser.js
+++ b/src/parser/hbs-parser.js
@@ -27,7 +27,7 @@ export function parseForESLint(code, options) {
 
   let result;
   try {
-    result = toTree(code, { templateOnly: true });
+    result = toTree(code, { templateOnly: true, tokens: true });
   } catch (e) {
     // Transform glimmer parse error to ESLint-compatible error
     const loc = e.location || (e.hash && e.hash.loc);
@@ -55,7 +55,14 @@ export function parseForESLint(code, options) {
     type: 'Program',
     body: [templateNode],
     tokens: templateNode.tokens,
-    comments,
+    // Normalize Glimmer comment nodes to type:'Block' so ESLint's inline-config
+    // scanner and plugin rules that filter on type recognise them as comments.
+    comments: (comments || []).map((c) => ({
+      type: 'Block',
+      value: c.value,
+      range: c.range,
+      loc: c.loc,
+    })),
     range: [0, code.length],
     start: 0,
     end: code.length,

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -119,12 +119,7 @@ function registerPathExpression(node, path, scopeManager) {
   if (glimmerIsKeyword(name)) return;
   const { scope, variable } = findVarInParentScopes(scopeManager, path, name) || {};
   if (scope) {
-    Object.defineProperty(node.head, 'parent', {
-      value: node,
-      configurable: true,
-      enumerable: false,
-      writable: true,
-    });
+    node.head.parent = node;
     registerNodeInScope(node.head, scope, variable);
   }
 }
@@ -154,13 +149,16 @@ function registerElementNode(node, path, scopeManager) {
 /**
  * Build Glimmer visitors for toTree that register scopes during traversal.
  * Returns null when scopeManager is unavailable so the caller can skip the walk.
+ * When `collectComments` is provided, appends Glimmer comment nodes to it so
+ * callers can forward them into program.comments after the walk.
  * @param {object|null} scopeManager
  * @param {boolean} isTypescript
+ * @param {Array|null} [collectComments] - optional array to collect Glimmer comment nodes into
  * @returns {object|null} visitors for toTree, or null to skip
  */
-export function buildGlimmerVisitors(scopeManager, isTypescript) {
+export function buildGlimmerVisitors(scopeManager, isTypescript, collectComments) {
   if (!scopeManager) return null;
-  return {
+  const visitors = {
     GlimmerPathExpression(node, path) {
       registerPathExpression(node, path, scopeManager);
     },
@@ -171,6 +169,12 @@ export function buildGlimmerVisitors(scopeManager, isTypescript) {
       registerBlockParams(node, path, scopeManager, isTypescript);
     },
   };
+  if (collectComments) {
+    const push = (node) => collectComments.push(node);
+    visitors.GlimmerMustacheCommentStatement = push;
+    visitors.GlimmerCommentStatement = push;
+  }
+  return visitors;
 }
 
 // ── registerGlimmerScopes (fallback for JS/oxc path) ──────────────────

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -28,13 +28,10 @@ try {
 // ── Scope helpers ─────────────────────────────────────────────────────
 
 function findParentScope(scopeManager, nodePath) {
-  let scope = null;
   let path = nodePath;
   while (path) {
-    scope = scopeManager.acquire(path.node, true);
-    if (scope) {
-      return scope;
-    }
+    const scope = scopeManager.acquire(path.node, true);
+    if (scope) return scope;
     path = path.parentPath;
   }
   return null;
@@ -122,7 +119,12 @@ function registerPathExpression(node, path, scopeManager) {
   if (glimmerIsKeyword(name)) return;
   const { scope, variable } = findVarInParentScopes(scopeManager, path, name) || {};
   if (scope) {
-    node.head.parent = node;
+    Object.defineProperty(node.head, 'parent', {
+      value: node,
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
     registerNodeInScope(node.head, scope, variable);
   }
 }
@@ -151,24 +153,22 @@ function registerElementNode(node, path, scopeManager) {
 
 /**
  * Build Glimmer visitors for toTree that register scopes during traversal.
- * Uses a getter for scopeManager so it's available after the parser callback runs.
- * @param {function} getScopeManager - returns the scopeManager (may be null initially)
+ * Returns null when scopeManager is unavailable so the caller can skip the walk.
+ * @param {object|null} scopeManager
  * @param {boolean} isTypescript
- * @returns {object} visitors for toTree
+ * @returns {object|null} visitors for toTree, or null to skip
  */
-export function buildGlimmerVisitors(getScopeManager, isTypescript) {
+export function buildGlimmerVisitors(scopeManager, isTypescript) {
+  if (!scopeManager) return null;
   return {
     GlimmerPathExpression(node, path) {
-      const sm = getScopeManager();
-      if (sm) registerPathExpression(node, path, sm);
+      registerPathExpression(node, path, scopeManager);
     },
     GlimmerElementNode(node, path) {
-      const sm = getScopeManager();
-      if (sm) registerElementNode(node, path, sm);
+      registerElementNode(node, path, scopeManager);
     },
     GlimmerBlockParams(node, path) {
-      const sm = getScopeManager();
-      if (sm) registerBlockParams(node, path, sm, isTypescript);
+      registerBlockParams(node, path, scopeManager, isTypescript);
     },
   };
 }

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2375,7 +2375,12 @@ export const NotFound = <template>
       expect(e.lineNumber).toBe(1);
       expect(e.column).toBe(19);
       expect(e.fileName).toBe('example.gts');
-      expect(e.message).toMatchInlineSnapshot(`"× Unexpected eof"`);
+      expect(e.message).toMatchInlineSnapshot(`
+        "× Unexpected eof
+           ╭────
+         1 │ console.log('test)
+           ╰────"
+      `);
     }
   });
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2375,14 +2375,7 @@ export const NotFound = <template>
       expect(e.lineNumber).toBe(1);
       expect(e.column).toBe(19);
       expect(e.fileName).toBe('example.gts');
-      expect(e.message).toMatchInlineSnapshot(`
-        "
-          × Unexpected eof
-           ╭────
-         1 │ console.log('test)
-           ╰────
-        "
-      `);
+      expect(e.message).toMatchInlineSnapshot(`"× Unexpected eof"`);
     }
   });
 

--- a/tests/program-comments-sort-order.test.js
+++ b/tests/program-comments-sort-order.test.js
@@ -1,0 +1,87 @@
+/**
+ * Regression test for the sorted-by-range invariant on Program.comments.
+ *
+ * ESLint's SourceCode builds `tokensAndComments = sortedMerge(tokens, comments)`
+ * and `createIndexMap(tokens, comments)` — both iterate comments and tokens
+ * with a merge that assumes each array is already sorted by `range[0]`. Every
+ * standard JS parser (espree, @babel/eslint-parser, @typescript-eslint/parser)
+ * honors that invariant.
+ *
+ * When a .gts file has a JS `/* *​/` comment interleaved between templates,
+ * TS-parser comments are spread into `program.comments` first and Glimmer
+ * template comments get appended — producing an array like
+ * `[jsAt56, glimmerAt23]` whose order doesn't match range order. The
+ * downstream effect is `sourceCode.getTokenBefore(glimmerComment)` /
+ * `getTokenAfter(glimmerComment)` returning wrong tokens (or tokens from
+ * entirely different template regions), because the `indexMap` keyed on
+ * unsorted input points at the wrong token index.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+
+describe('program.comments sort order (ESLint tokensAndComments invariant)', () => {
+  const mixedSource = [
+    'const X = <template>',
+    '  {{! glimmer comment at 22 }}',
+    '</template>;',
+    '/* js comment at 56 */',
+    'const Y = 1;',
+  ].join('\n');
+
+  it('ast.comments is sorted by range[0]', () => {
+    const { ast } = parseForESLint(mixedSource, {
+      filePath: 't.gts',
+      range: true,
+      loc: true,
+      comment: true,
+      tokens: true,
+    });
+    const starts = (ast.comments || []).map((c) => c.range[0]);
+    const sorted = [...starts].sort((a, b) => a - b);
+    expect(starts).toEqual(sorted);
+  });
+
+  it('getTokenBefore / getTokenAfter on a Glimmer comment return source-adjacent tokens', () => {
+    const linter = new Linter();
+    linter.defineParser('p', { parseForESLint });
+    const probes = [];
+    linter.defineRule('probe', {
+      create(context) {
+        return {
+          'Program:exit'() {
+            const sc = context.sourceCode;
+            for (const c of sc.getAllComments()) {
+              if (c.value.includes('glimmer')) {
+                probes.push({
+                  commentRange: c.range,
+                  before: sc.getTokenBefore(c)?.range ?? null,
+                  after: sc.getTokenAfter(c)?.range ?? null,
+                });
+              }
+            }
+          },
+        };
+      },
+    });
+    linter.verify(
+      mixedSource,
+      {
+        parser: 'p',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { probe: 'error' },
+      },
+      { filename: 't.gts' }
+    );
+    expect(probes).toHaveLength(1);
+    const { commentRange, before, after } = probes[0];
+    // Whatever the exact adjacent token ranges are, they must bracket the
+    // comment — the token before must end at or before the comment's start,
+    // and the token after must start at or after the comment's end.
+    expect(before).not.toBeNull();
+    expect(after).not.toBeNull();
+    expect(before[1]).toBeLessThanOrEqual(commentRange[0]);
+    expect(after[0]).toBeGreaterThanOrEqual(commentRange[1]);
+  });
+});


### PR DESCRIPTION
Builds on [#196](https://github.com/ember-tooling/ember-eslint-parser/pull/196) (this branch was cut from `pr-196` and will need that merged first — noted in the commit). Adds the missing sort on `program.comments` + a regression test.

## Problem

TS-parser comments are spread into `program.comments` first; Glimmer template comments are then appended from the closure's `glimmerComments` accumulator. For files that interleave JS `/* */` comments between templates, the result is out of range order:

```js
const X = <template>{{! glimmer at 22 }}</template>;
/* js at 56 */
const Y = 1;
// ast.comments: [[65,87] js, [23,51] glimmer]  ← unsorted
```

ESLint's `SourceCode` builds `tokensAndComments = sortedMerge(ast.tokens, ast.comments)` and the token-store's `createIndexMap(tokens, comments)` — both assume each input array is already sorted by `range[0]` (espree, `@typescript-eslint/parser`, `@babel/eslint-parser` all honor that invariant). With unsorted comments, the index map points at wrong token indices for positions whose nearest comment was iterated out of order, which surfaces as wrong answers from `sourceCode.getTokenBefore(commentNode)` / `getTokenAfter(commentNode)`.

## Observed

|  | `getTokenBefore(glimmer@[23,51])` | `getTokenAfter(glimmer@[23,51])` |
|---|---|---|
| Current #196 | `;` @ [63,64] (wrong — *after* the comment) | `const` @ [88,93] (skips `</template>`) |
| With `.sort()` | `<template>` @ [10,20] | `</template>` @ [52,63] |

## Fix

One line in `gjs-gts-parser.js`:

```diff
     programNode.comments = [
       ...(programNode.comments || []),
       ...glimmerComments.map((c) => ({ type: 'Block', value: c.value, range: c.range, loc: c.loc })),
-    ];
+    ].sort((a, b) => a.range[0] - b.range[0]);
```

## Regression test

`tests/program-comments-sort-order.test.js` covers both the structural assertion (`ast.comments` sorted by `range[0]`) and the downstream observable (bracketing tokens returned by `getTokenBefore` / `getTokenAfter`).

Verified: both tests fail against current #196, pass with the one-liner. Full suite: 47/47.

## `.hbs` path

Not touched here. `hbs-parser.js` builds `comments: (comments || []).map(...)` from a single template's output, which comes out in source order in practice — so no observable bug to fix. If you want symmetry, `.sort()` there too is free insurance; happy to include in a follow-up.

## Merge coordination

Diff currently includes #196's commits too (branch was cut from `pr-196`). Easiest path: squash-merge #196 first, then rebase this on `main`. Or cherry-pick the last commit (`aca8da9 fix(gjs-gts): sort program.comments …`) onto `pr-196`.