### PR TITLE
fix: add test for failing regression and fix program.comments not sorted by range

### DIFF
--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -232,7 +232,7 @@ export function parseForESLint(code, options) {
             range: c.range,
             loc: c.loc,
           })),
-        ];
+        ].sort((a, b) => a.range[0] - b.range[0]);
       }
     }
 

--- a/tests/program-comments-sort-order.test.js
+++ b/tests/program-comments-sort-order.test.js
@@ -1,0 +1,87 @@
+/**
+ * Regression test for the sorted-by-range invariant on Program.comments.
+ *
+ * ESLint's SourceCode builds `tokensAndComments = sortedMerge(tokens, comments)`
+ * and `createIndexMap(tokens, comments)` — both iterate comments and tokens
+ * with a merge that assumes each array is already sorted by `range[0]`. Every
+ * standard JS parser (espree, @babel/eslint-parser, @typescript-eslint/parser)
+ * honors that invariant.
+ *
+ * When a .gts file has a JS block comment (slash-star style) interleaved between templates,
+ * TS-parser comments are spread into `program.comments` first and Glimmer
+ * template comments get appended — producing an array like
+ * `[jsAt56, glimmerAt23]` whose order doesn't match range order. The
+ * downstream effect is `sourceCode.getTokenBefore(glimmerComment)` /
+ * `getTokenAfter(glimmerComment)` returning wrong tokens (or tokens from
+ * entirely different template regions), because the `indexMap` keyed on
+ * unsorted input points at the wrong token index.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+
+describe('program.comments sort order (ESLint tokensAndComments invariant)', () => {
+  const mixedSource = [
+    'const X = <template>',
+    '  {{! glimmer comment at 22 }}',
+    '</template>;',
+    '/* js comment at 56 */',
+    'const Y = 1;',
+  ].join('\n');
+
+  it('ast.comments is sorted by range[0]', () => {
+    const { ast } = parseForESLint(mixedSource, {
+      filePath: 't.gts',
+      range: true,
+      loc: true,
+      comment: true,
+      tokens: true,
+    });
+    const starts = (ast.comments || []).map((c) => c.range[0]);
+    const sorted = [...starts].sort((a, b) => a - b);
+    expect(starts).toEqual(sorted);
+  });
+
+  it('getTokenBefore / getTokenAfter on a Glimmer comment return source-adjacent tokens', () => {
+    const linter = new Linter();
+    linter.defineParser('p', { parseForESLint });
+    const probes = [];
+    linter.defineRule('probe', {
+      create(context) {
+        return {
+          'Program:exit'() {
+            const sc = context.sourceCode;
+            for (const c of sc.getAllComments()) {
+              if (c.value.includes('glimmer')) {
+                probes.push({
+                  commentRange: c.range,
+                  before: sc.getTokenBefore(c)?.range ?? null,
+                  after: sc.getTokenAfter(c)?.range ?? null,
+                });
+              }
+            }
+          },
+        };
+      },
+    });
+    linter.verify(
+      mixedSource,
+      {
+        parser: 'p',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { probe: 'error' },
+      },
+      { filename: 't.gts' }
+    );
+    expect(probes).toHaveLength(1);
+    const { commentRange, before, after } = probes[0];
+    // Whatever the exact adjacent token ranges are, they must bracket the
+    // comment — the token before must end at or before the comment's start,
+    // and the token after must start at or after the comment's end.
+    expect(before).not.toBeNull();
+    expect(after).not.toBeNull();
+    expect(before[1]).toBeLessThanOrEqual(commentRange[0]);
+    expect(after[0]).toBeGreaterThanOrEqual(commentRange[1]);
+  });
+});


### PR DESCRIPTION
Follow-up to #196.

## Observed

With #196 applied, `program.comments` comes out unsorted whenever a JS `/* */` comment sits between two templates:

```js
const X = <template>
  {{! glimmer comment at 22 }}
</template>;
/* js comment at 56 */
const Y = 1;
// ast.comments: [[65,87] js, [23,51] glimmer]  ← unsorted
```

ESLint's `SourceCode` builds `tokensAndComments = sortedMerge(ast.tokens, ast.comments)` and the token-store's `createIndexMap(tokens, comments)` — both assume each input array is sorted by `range[0]` (espree, `@typescript-eslint/parser`, `@babel/eslint-parser` all honor that invariant). With unsorted comments, the index map points at the wrong token indices for positions whose nearest comment was iterated out of order, which surfaces as wrong answers from `sourceCode.getTokenBefore(commentNode)` / `getTokenAfter(commentNode)`:

|  | `getTokenBefore(glimmer@[23,51])` | `getTokenAfter(glimmer@[23,51])` |
|---|---|---|
| #196 as-is | `;` @ [63,64] (wrong — *after* the comment) | `const` @ [88,93] (skips `</template>`) |
| with this PR | `<template>` @ [10,20] | `</template>` @ [52,63] |

## Commits

1. `test:` — `tests/program-comments-sort-order.test.js`, two tests that pin the invariant:
   - **Structural**: `ast.comments.map(c => c.range[0])` equals its sorted copy.
   - **End-to-end via `Linter`**: for the `{{! }}` comment, `getTokenBefore` / `getTokenAfter` return tokens that bracket the comment (before-end ≤ comment-start, after-start ≥ comment-end).
2. `fix:` — sort the concatenated array after appending Glimmer comments in `gjs-gts-parser.js` (`programNode.comments = […TS, …glimmer].sort((a, b) => a.range[0] - b.range[0])`).

## Verification

- Both tests fail on the `test:` commit alone, pass after `fix:`.
- `npm run lint` and `prettier --check` clean.

## Review comment companion

I also ran [eslint-plugin-ember#2733](https://github.com/ember-cli/eslint-plugin-ember/pull/2733)'s five-test directive suite against #196 + this fix — all 5 pass.