### PR TITLE
fix: JS path uses espree so ESLint sees loc, range, tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "content-tag": "^4.1.1",
     "ember-estree": "^0.6.2",
     "eslint-scope": "^9.1.2",
+    "espree": "^10.4.0",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",
     "svg-tags": "^1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
+      espree:
+        specifier: ^10.4.0
+        version: 10.4.0
       html-tags:
         specifier: ^5.1.0
         version: 5.1.0
@@ -3136,8 +3139,8 @@ packages:
       jiti:
         optional: true
 
-  espree@10.3.0:
-    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
@@ -6777,7 +6780,7 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3
-      espree: 10.3.0
+      espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.0
@@ -7889,9 +7892,13 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.16.0
 
   acorn@8.14.0: {}
 
@@ -9762,7 +9769,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.0
-      espree: 10.3.0
+      espree: 10.4.0
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -9780,10 +9787,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  espree@10.3.0:
+  espree@10.4.0:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
@@ -10960,7 +10967,7 @@ snapshots:
 
   mlly@1.7.3:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.16.0
       pathe: 1.1.2
       pkg-types: 1.3.0
       ufo: 1.5.4

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -5,6 +5,7 @@ import { patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser } f
 import { buildGlimmerVisitors } from './transforms.js';
 import { toTree } from 'ember-estree';
 import * as eslintScope from 'eslint-scope';
+import * as espree from 'espree';
 
 const require = createRequire(import.meta.url);
 
@@ -185,12 +186,18 @@ export function parseForESLint(code, options) {
             return tsResult;
           }
         : (placeholderJS) => {
-            // JS path: parse with oxc, create scope manager from placeholder AST
-            const { parseSync } = require('oxc-parser');
-            const oxcResult = parseSync(filePath || 'input.js', placeholderJS);
-            const program = oxcResult.program;
-            program.tokens = oxcResult.tokens || [];
-            program.comments = oxcResult.comments || [];
+            // JS path: parse with espree so the AST already carries loc/range,
+            // tokens, and comments — what ESLint validates and rules consume.
+            // (oxc-parser doesn't emit loc or tokens, so its output fails
+            // ESLint's SourceCode validation on the program node.)
+            const program = espree.parse(placeholderJS, {
+              ecmaVersion: 'latest',
+              sourceType: 'module',
+              loc: true,
+              range: true,
+              tokens: true,
+              comment: true,
+            });
             scopeManager = eslintScope.analyze(program, {
               ecmaVersion: 2022,
               sourceType: 'module',

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -188,8 +188,14 @@ export function parseForESLint(code, options) {
         : (placeholderJS) => {
             // JS path: parse with espree so the AST already carries loc/range,
             // tokens, and comments — what ESLint validates and rules consume.
-            // (oxc-parser doesn't emit loc or tokens, so its output fails
-            // ESLint's SourceCode validation on the program node.)
+            //
+            // We'd prefer oxc-parser here (faster, already used elsewhere in
+            // the pipeline), but its JS API exposes only `start`/`end` byte
+            // offsets and an opt-in `range` array — no `loc`, no token
+            // stream — so its output fails ESLint's SourceCode validation
+            // on the Program node and breaks any rule that walks tokens.
+            // Switch back once oxc lands native loc support:
+            //   https://github.com/oxc-project/oxc/issues/10307
             const program = espree.parse(placeholderJS, {
               ecmaVersion: 'latest',
               sourceType: 'module',

--- a/tests/js-path.test.js
+++ b/tests/js-path.test.js
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for the JS-fallback parse path.
+ *
+ * The JS path runs when @typescript-eslint/parser isn't available (or when
+ * `useBabel: true` is set). Historically this path produced an AST that
+ * ESLint refused — `oxc-parser` only emits `start`/`end` byte offsets, so
+ * `Program.loc` and `Program.range` were missing and `Program.tokens` was
+ * empty. Lint of any .gjs file blew up with `TypeError: AST is missing
+ * location information.`, and rules that walk tokens (e.g. no-dupe-args)
+ * crashed even after that.
+ *
+ * These tests force the JS path via `useBabel: true` and pin the contract
+ * at two layers: the AST shape the parser returns, and a real Linter pass
+ * driving an ESLint rule that walks tokens. Both fail under oxc.
+ *
+ * Switch back to oxc once https://github.com/oxc-project/oxc/issues/10307
+ * lands native loc support.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+
+describe('JS path (useBabel) — AST shape ESLint requires', () => {
+  const code = [
+    "import currentYear from './helper.js';",
+    '',
+    '<template>',
+    '  <p>{{(currentYear)}}, hi</p>',
+    '</template>',
+  ].join('\n');
+
+  const result = parseForESLint(code, {
+    filePath: 'fixture.gjs',
+    useBabel: true,
+  });
+
+  it('Program node carries loc, range, tokens, and comments', () => {
+    const ast = result.ast;
+    expect(ast.type).toBe('Program');
+    expect(ast.loc).toBeDefined();
+    expect(ast.loc.start).toMatchObject({ line: expect.any(Number), column: expect.any(Number) });
+    expect(ast.loc.end).toMatchObject({ line: expect.any(Number), column: expect.any(Number) });
+    expect(ast.range).toEqual([expect.any(Number), expect.any(Number)]);
+    expect(Array.isArray(ast.tokens)).toBe(true);
+    expect(ast.tokens.length).toBeGreaterThan(0);
+    expect(Array.isArray(ast.comments)).toBe(true);
+  });
+
+  it('inner JS nodes carry loc and range (rules read these everywhere)', () => {
+    const importDecl = result.ast.body[0];
+    expect(importDecl.type).toBe('ImportDeclaration');
+    expect(importDecl.loc).toBeDefined();
+    expect(importDecl.range).toEqual([expect.any(Number), expect.any(Number)]);
+  });
+
+  it('produces a scope manager that resolves the import', () => {
+    expect(result.scopeManager).toBeDefined();
+    const moduleScope = result.scopeManager.scopes.find((s) => s.type === 'module');
+    expect(moduleScope).toBeDefined();
+    expect(moduleScope.set.has('currentYear')).toBe(true);
+  });
+});
+
+describe('JS path (useBabel) — end-to-end Linter pass', () => {
+  function makeLinter() {
+    const linter = new Linter();
+    linter.defineParser('ember-eslint-parser', {
+      parseForESLint: (code, options) => parseForESLint(code, { ...options, useBabel: true }),
+    });
+    return linter;
+  }
+
+  it('lints a .gjs file without throwing on missing loc/tokens', () => {
+    const linter = makeLinter();
+    const code = [
+      "import currentYear from './helper.js';",
+      '',
+      '<template>',
+      '  <p>{{(currentYear)}}, hi</p>',
+      '</template>',
+    ].join('\n');
+
+    // `no-dupe-args` is a core rule that calls
+    // `astUtils.getOpeningParenOfParams(...).loc.start`, which reaches
+    // through the token stream. Under the oxc path this throws because
+    // `program.tokens` is empty. Enabling the rule keeps that surface
+    // covered even if a future change quietly restores `loc` but still
+    // ships an empty token array.
+    const messages = linter.verify(
+      code,
+      {
+        parser: 'ember-eslint-parser',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { 'no-dupe-args': 'error' },
+      },
+      { filename: 'fixture.gjs' }
+    );
+
+    // The fatal "AST is missing location information" / "Cannot read
+    // properties of null (reading 'loc')" errors land here as
+    // `fatal: true` messages — assert there are none.
+    const fatal = messages.filter((m) => m.fatal);
+    expect(fatal).toEqual([]);
+  });
+
+  it('marks template-only references as used (scope wiring is intact)', () => {
+    const linter = makeLinter();
+    const code = [
+      "import currentYear from './helper.js';",
+      '',
+      '<template>',
+      '  <p>{{(currentYear)}}, hi</p>',
+      '</template>',
+    ].join('\n');
+
+    const messages = linter.verify(
+      code,
+      {
+        parser: 'ember-eslint-parser',
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { 'no-unused-vars': 'error' },
+      },
+      { filename: 'fixture.gjs' }
+    );
+
+    const unused = messages.filter((m) => m.ruleId === 'no-unused-vars');
+    expect(unused).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The JS-fallback path (taken when `@typescript-eslint/parser` isn't installed) parsed with `oxc-parser`, but oxc emits only `start`/`end` byte offsets — no `loc`, no `range` array, no `tokens`. ESLint's `SourceCode.validate()` requires `loc` and `range` on the Program node, so linting any `.gjs` file in a project without `@typescript-eslint/parser` fails with:

```
TypeError: AST is missing location information.
    at validate (eslint/lib/languages/js/source-code/source-code.js:63:9)
```

Even if `loc`/`range` are backfilled, the next rule that walks tokens (e.g. `no-dupe-args`) blows up because `program.tokens` is empty — oxc doesn't emit tokens at all.

Switch the JS path to `espree` (already a transitive dep of `eslint`; now declared directly). Espree produces an ESLint-compatible AST with `loc`, `range`, `tokens`, and `comments` natively. The TS path is untouched.

## Repro

A consumer hit this in https://github.com/bobisjan/website/pull/2263 — a project that doesn't use TypeScript and doesn't install `@typescript-eslint/parser`. Lint now passes against that branch with this fix applied.

## Test plan

- [x] `pnpm test` — all 47 existing tests pass
- [x] Verified end-to-end against bobisjan/website PR 2263: `pnpm lint` succeeds after patching the installed parser with this change (also requires the `ember-estree ^0.6.2` bump that already landed in v0.11.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)