### PR TITLE
fix: route JS path through @babel/eslint-parser so decorators parse

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,7 @@
+// Used by tests that exercise the JS-path of ember-eslint-parser, which
+// delegates to @babel/eslint-parser. The decorators plugin lets fixtures
+// pin behaviour for `@tracked` / `@service`-style class-field decorators
+// — the syntax that broke when the JS fallback was raw espree.
+module.exports = {
+  plugins: [['@babel/plugin-proposal-decorators', { version: 'legacy' }]],
+};

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "content-tag": "^4.1.1",
     "ember-estree": "^0.6.2",
     "eslint-scope": "^9.1.2",
-    "espree": "^10.4.0",
     "html-tags": "^5.1.0",
     "mathml-tag-names": "^4.0.0",
     "svg-tags": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",
+    "@babel/eslint-parser": "^7.28.6",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@typescript-eslint/parser": "^7.1.0",
     "@typescript-eslint/scope-manager": "^7.1.0",
     "@typescript-eslint/visitor-keys": "^7.1.0",
@@ -65,9 +66,13 @@
     "vitest": "^1.2.2"
   },
   "peerDependencies": {
+    "@babel/eslint-parser": "^7.28.6",
     "@typescript-eslint/parser": "*"
   },
   "peerDependenciesMeta": {
+    "@babel/eslint-parser": {
+      "optional": true
+    },
     "@typescript-eslint/parser": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       eslint-scope:
         specifier: ^9.1.2
         version: 9.1.2
-      espree:
-        specifier: ^10.4.0
-        version: 10.4.0
       html-tags:
         specifier: ^5.1.0
         version: 5.1.0
@@ -42,6 +39,12 @@ importers:
       '@babel/core':
         specifier: ^7.23.6
         version: 7.26.0
+      '@babel/eslint-parser':
+        specifier: ^7.28.6
+        version: 7.28.6(@babel/core@7.26.0)(eslint@8.57.1)
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.26.0)
       '@typescript-eslint/parser':
         specifier: ^7.1.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.2)
@@ -1639,48 +1642,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.119.0':
     resolution: {integrity: sha512-7BOq/tjSrtnp/ihw615uGcxMY3iya2qvVtwm15h2NvBZ6Jje+PC1GSUBOLfqGKJbUr9riSVV//a4iNhHI48Qdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
     resolution: {integrity: sha512-PQIrLJwoAaNyNSWBF+2SSgv44Jp+xpKVUA+8+PuoMhyBQ6lFSbQdaxewdn11i3heTFMYd2xF339HWax4S6MPVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
     resolution: {integrity: sha512-spNh4YhT9K+Ya5hr6NmI1MazKSKORD8u5/06hFbzTslLnmmxiGaLqJXhNKIYUH39ne/JD5rkoRkUcOB2/LpC3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
     resolution: {integrity: sha512-hFoCTRxSJAcrNBYVlgNDDQq6LyJLYyhnJDlPtK/mWrPYS3x5/fUR9jc6wo5VyxKIL/0dDJBBWp19v81q9heU/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
     resolution: {integrity: sha512-bl7jHJZq3W5tYEvKG3yWZTUKTNb0/BtyYSnfMIrQ7t8hajCH4i1g0q+14s0KmQQl1UHxIX/Gx/Ps6e92qJQJmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.119.0':
     resolution: {integrity: sha512-m+DE7NhJIEGp4efSJnNfRf3swT25rbZ1FTIihV+pOLTI+k5yNguxvqT338mNu61OVSx0BfpV8QlO2nz43GR/Zg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.119.0':
     resolution: {integrity: sha512-pHhnXZHUfd5pYzFLQfvx1DH2HY+L8DPZeh6SsQrsmoaODm1+j8VPeWLwGSrXQSz5f1kfT/mnzm1iNLVOGIeuaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.119.0':
     resolution: {integrity: sha512-8Fthv9nOec0hQLX16yjYyYIU+u8ZFuQojdQ3vNgXN+PcqI/bDohGgCATrxO69gLf0IzkyOmKmurXOQCYK8BYpQ==}
@@ -1768,51 +1779,61 @@ packages:
     resolution: {integrity: sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.30.1':
     resolution: {integrity: sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.30.1':
     resolution: {integrity: sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.30.1':
     resolution: {integrity: sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
     resolution: {integrity: sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
     resolution: {integrity: sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.30.1':
     resolution: {integrity: sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.30.1':
     resolution: {integrity: sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.30.1':
     resolution: {integrity: sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.30.1':
     resolution: {integrity: sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.30.1':
     resolution: {integrity: sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==}

--- a/src/parser/gjs-gts-parser.js
+++ b/src/parser/gjs-gts-parser.js
@@ -4,10 +4,25 @@ import { registerParsedFile } from '../preprocessor/noop.js';
 import { patchTs, replaceExtensions, syncMtsGtsSourceFiles, typescriptParser } from './ts-patch.js';
 import { buildGlimmerVisitors } from './transforms.js';
 import { toTree } from 'ember-estree';
-import * as eslintScope from 'eslint-scope';
-import * as espree from 'espree';
 
 const require = createRequire(import.meta.url);
+
+// Resolved once at module load via createRequire — top-level `await import()`
+// would mark the module as async, and the bench harness loads parsers
+// synchronously through `createRequire`. `@babel/eslint-parser` is an optional
+// peer (TS-only setups don't need it), so a missing dep yields null and the JS
+// path below emits a targeted error.
+//
+// The experimental-worker entry point runs babel in a worker and matches the
+// parser ember-cli wires up for plain `.js` files in JS-only apps, so config
+// discovery (decorators & friends) lines up with how the rest of the project
+// is being parsed.
+let babelParser = null;
+try {
+  babelParser = require('@babel/eslint-parser/experimental-worker');
+} catch {
+  // optional peer; left null
+}
 
 /**
  * implements https://eslint.org/docs/latest/extend/custom-parsers
@@ -186,30 +201,25 @@ export function parseForESLint(code, options) {
             return tsResult;
           }
         : (placeholderJS) => {
-            // JS path: parse with espree so the AST already carries loc/range,
-            // tokens, and comments — what ESLint validates and rules consume.
-            //
-            // We'd prefer oxc-parser here (faster, already used elsewhere in
-            // the pipeline), but its JS API exposes only `start`/`end` byte
-            // offsets and an opt-in `range` array — no `loc`, no token
-            // stream — so its output fails ESLint's SourceCode validation
-            // on the Program node and breaks any rule that walks tokens.
-            // Switch back once oxc lands native loc support:
-            //   https://github.com/oxc-project/oxc/issues/10307
-            const program = espree.parse(placeholderJS, {
-              ecmaVersion: 'latest',
-              sourceType: 'module',
-              loc: true,
-              range: true,
-              tokens: true,
-              comment: true,
+            // JS path: defer to @babel/eslint-parser, which discovers the
+            // consuming app's babel config and applies its plugins (notably
+            // decorators) when parsing. That keeps gjs aligned with how the
+            // app's plain `.js` files are parsed, so syntax accepted there
+            // is accepted here without a second parser config.
+            if (!babelParser) {
+              throw new Error(
+                'ember-eslint-parser: linting `.gjs`/`.gts` files in a JS-only ' +
+                  'project requires `@babel/eslint-parser`. Install it as a ' +
+                  'dev dependency, or install `@typescript-eslint/parser` to ' +
+                  'opt into the TypeScript-based path.'
+              );
+            }
+            const babelResult = babelParser.parseForESLint(placeholderJS, {
+              ...options,
+              filePath,
             });
-            scopeManager = eslintScope.analyze(program, {
-              ecmaVersion: 2022,
-              sourceType: 'module',
-              range: true,
-            });
-            return { ast: program, scopeManager };
+            scopeManager = babelResult.scopeManager;
+            return babelResult;
           },
       // Factory form: scopeManager is set by the parser callback before this
       // runs. Returns null when unavailable so ember-estree skips the walk.

--- a/tests/js-path.test.js
+++ b/tests/js-path.test.js
@@ -2,24 +2,29 @@
  * Regression tests for the JS-fallback parse path.
  *
  * The JS path runs when @typescript-eslint/parser isn't available (or when
- * `useBabel: true` is set). Historically this path produced an AST that
- * ESLint refused — `oxc-parser` only emits `start`/`end` byte offsets, so
- * `Program.loc` and `Program.range` were missing and `Program.tokens` was
- * empty. Lint of any .gjs file blew up with `TypeError: AST is missing
- * location information.`, and rules that walk tokens (e.g. no-dupe-args)
- * crashed even after that.
+ * `useBabel: true` is set). It now defers to @babel/eslint-parser, which
+ * picks up the consuming app's babel config — so any plugin enabled there
+ * (decorators, etc.) is honoured when linting `.gjs` files.
  *
- * These tests force the JS path via `useBabel: true` and pin the contract
- * at two layers: the AST shape the parser returns, and a real Linter pass
- * driving an ESLint rule that walks tokens. Both fail under oxc.
+ * Two earlier shapes of this path each broke ESLint differently:
+ *   - oxc-parser emitted only `start`/`end` byte offsets, so `Program.loc`
+ *     and `Program.range` were missing and `Program.tokens` was empty.
+ *     Lint of any .gjs file blew up with `TypeError: AST is missing
+ *     location information.`, and rules that walk tokens (e.g.
+ *     no-dupe-args) crashed even after that.
+ *   - raw espree carries loc/tokens but rejects modern syntax outright —
+ *     `@tracked count = 0;` produced `SyntaxError: Unexpected character '@'`
+ *     for every JS-only ember app.
  *
- * Switch back to oxc once https://github.com/oxc-project/oxc/issues/10307
- * lands native loc support.
+ * These tests force the JS path via `useBabel: true` and pin three
+ * contracts: the AST shape ESLint requires, decorator syntax parses
+ * cleanly, and a real Linter pass walks tokens without throwing.
  */
 
 import { describe, expect, it } from 'vitest';
 import { Linter } from 'eslint';
 import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+import { traverse } from '../src/parser/transforms.js';
 
 describe('JS path (useBabel) — AST shape ESLint requires', () => {
   const code = [
@@ -62,6 +67,42 @@ describe('JS path (useBabel) — AST shape ESLint requires', () => {
   });
 });
 
+describe('JS path (useBabel) — class decorators', () => {
+  // Regression: when @typescript-eslint/parser isn't installed, the JS path
+  // historically fell back to raw espree, which rejects `@decorator` syntax
+  // outright (`SyntaxError: Unexpected character '@'`). Routing the JS path
+  // through @babel/eslint-parser picks up the consuming app's babel config —
+  // the decorators plugin lives there for ember apps — so a `.gjs` file with
+  // a `@tracked` field parses cleanly without any TypeScript tooling.
+  const code = [
+    "import Component from '@glimmer/component';",
+    "import { tracked } from '@glimmer/tracking';",
+    '',
+    'export default class Counter extends Component {',
+    '  @tracked count = 0;',
+    '  <template>{{this.count}}</template>',
+    '}',
+  ].join('\n');
+
+  it('parses a class field decorator without throwing', () => {
+    const result = parseForESLint(code, {
+      filePath: 'fixture.gjs',
+      useBabel: true,
+    });
+    expect(result.ast.type).toBe('Program');
+
+    let decoratorName = null;
+    traverse(result.visitorKeys, result.ast, (path) => {
+      const decorators = path.node?.decorators;
+      if (Array.isArray(decorators) && decorators.length > 0) {
+        const expr = decorators[0].expression;
+        decoratorName = expr?.name ?? expr?.callee?.name ?? null;
+      }
+    });
+    expect(decoratorName).toBe('tracked');
+  });
+});
+
 describe('JS path (useBabel) — end-to-end Linter pass', () => {
   function makeLinter() {
     const linter = new Linter();
@@ -83,10 +124,10 @@ describe('JS path (useBabel) — end-to-end Linter pass', () => {
 
     // `no-dupe-args` is a core rule that calls
     // `astUtils.getOpeningParenOfParams(...).loc.start`, which reaches
-    // through the token stream. Under the oxc path this throws because
-    // `program.tokens` is empty. Enabling the rule keeps that surface
-    // covered even if a future change quietly restores `loc` but still
-    // ships an empty token array.
+    // through the token stream. Enabling it pins the contract that the
+    // JS path emits a populated `program.tokens` — earlier oxc-based
+    // implementations shipped an empty array and crashed every rule
+    // that walked tokens.
     const messages = linter.verify(
       code,
       {


### PR DESCRIPTION
## Summary

Fixes parse errors on every `.gjs` file containing `@tracked`, `@service`, `@action`, or any other decorator in JS-only ember apps. The JS-fallback parse path (used when `@typescript-eslint/parser` is not installed) now defers to `@babel/eslint-parser`, which discovers the consuming app's `babel.config.*` and applies its plugins — decorators included.

## Problem

The JS path has gone through two shapes, and each broke real apps differently:

- **oxc-parser**: emits only `start`/`end` byte offsets — no `loc`, no `range` array, no token stream. ESLint's `SourceCode.validate()` rejected the `Program` node, and rules that walk tokens (e.g. `no-dupe-args`) crashed.
- **espree** (current `main`): carries `loc`/`tokens` but is acorn-based, and acorn rejects `@decorator` syntax outright. A fresh `ember-cli` app generated today, after upgrading `eslint-plugin-ember` to 13.x, fails with `SyntaxError: Unexpected character '@'` the first time it tries to lint any component using `@tracked`.

Repro against `eslint-plugin-ember@13.1.3` + this package on `main`, no `@typescript-eslint/parser` installed:

```js
// app/components/counter.gjs
import Component from '@glimmer/component';
import { tracked } from '@glimmer/tracking';

export default class Counter extends Component {
  @tracked count = 0;
  <template>{{this.count}}</template>
}
```

```
$ pnpm exec eslint app/components/counter.gjs
SyntaxError: Unexpected character '@'
    at Espree.raise (.../espree/lib/espree.js:263:25)
    ...
  6:3  error  Parsing error: Unexpected character '@'
```

## Fix

The JS path now lazily loads `@babel/eslint-parser/experimental-worker` and delegates to its `parseForESLint`. That's the same parser `ember-cli` already wires up for plain `.js` files in the generated `eslint.config.mjs`, so syntax accepted there is now accepted here too — no second parser config to keep in sync.

`@babel/eslint-parser` is declared as an optional peer alongside `@typescript-eslint/parser`. If neither is installed the JS path throws a clear "install one of these" error instead of the cryptic acorn one. The TypeScript path is unchanged.

A minimal `babel.config.cjs` (legacy decorators plugin) is added at the repo root so the package's own tests exercise babel config discovery against a realistic config.

## Test plan
- [x] `pnpm test` — 53 tests pass, including a new `tests/js-path.test.js` regression case that pins decorator parsing in a `.gjs` file (`@tracked count = 0;` produces a `Decorator` node with `expression.name === 'tracked'`).
- [x] `pnpm run lint:js` — clean.
- [x] End-to-end: in a fresh `ember-cli@6.12.0` app with `eslint-plugin-ember@13.1.3` and **no** `@typescript-eslint/parser`, with this package linked via `pnpm.overrides`, `pnpm exec eslint .` exits 0 on the gjs decorator fixture above.

## Notes

- This supersedes the espree-based interim work — espree never solved the JS path because acorn doesn't accept decorators. Keeping `oxc-parser` for the inner walks (where `ember-estree` already uses it) is fine; only the ESLint-facing parse changes here.
- For TypeScript users nothing changes: `@typescript-eslint/parser` continues to handle `.gts` (and decorator-bearing `.gjs` if they happen to use the TS path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)