### PR TITLE
feat: skip Ember 7.1 built-in template keywords in scope registration

### DIFF
--- a/src/parser/ember71-built-in-keywords.js
+++ b/src/parser/ember71-built-in-keywords.js
@@ -1,0 +1,94 @@
+import { createRequire } from 'node:module';
+
+/**
+ * Built-in template keywords shipped from `ember-source` 7.1.0
+ * (RFCs 389, 470, 560, 561, 562, 997, 998, 999, 1000). They can be referenced
+ * in strict-mode (`.gjs` / `.gts`) templates without an explicit import.
+ *
+ * `@glimmer/syntax`'s `isKeyword` does not (yet) include these, so the
+ * scope-registration pass would otherwise treat `{{eq}}`, `{{on}}`, etc. as
+ * free identifiers and ESLint's `no-undef` would flag them.
+ *
+ * Mirrors Glint's `KeywordsForEmber71` gate in
+ * `@glint/ember-tsc/types/-private/dsl/globals.d.ts`.
+ */
+export const EMBER_71_BUILT_IN_KEYWORDS = new Set([
+  'and',
+  'array',
+  'element',
+  'eq',
+  'fn',
+  'gt',
+  'gte',
+  'hash',
+  'lt',
+  'lte',
+  'neq',
+  'not',
+  'on',
+  'or',
+]);
+
+/**
+ * Returns `true` when `name` is one of the Ember 7.1 built-in template
+ * keywords AND the supplied `ember-source` version is >= 7.1.0.
+ *
+ * Pure — accepts the version string instead of reading the filesystem so it
+ * is trivially testable.
+ *
+ * @param {string} name
+ * @param {string | undefined | null} version
+ * @returns {boolean}
+ */
+export function isEmber71BuiltInKeywordForVersion(name, version) {
+  if (!EMBER_71_BUILT_IN_KEYWORDS.has(name)) return false;
+  if (typeof version !== 'string') return false;
+
+  const [major, minor] = version.split('.').map(Number);
+  return major > 7 || (major === 7 && minor >= 1);
+}
+
+const require = createRequire(import.meta.url);
+
+let cachedVersion;
+let cachedVersionResolved = false;
+
+function resolveEmberSourceVersion() {
+  if (cachedVersionResolved) return cachedVersion;
+  cachedVersionResolved = true;
+  try {
+    // ember-source is a peer of consumers, not of this parser.
+    // eslint-disable-next-line n/no-missing-require, import/no-unresolved
+    const pkg = require('ember-source/package.json');
+    cachedVersion = typeof pkg?.version === 'string' ? pkg.version : undefined;
+  } catch {
+    cachedVersion = undefined;
+  }
+  return cachedVersion;
+}
+
+/**
+ * Decide whether `name` should be treated as a built-in template keyword
+ * given the consumer's installed `ember-source`. Returns `false` when
+ * `ember-source` is not resolvable or its version is older than 7.1.0, so
+ * pre-7.1 projects keep their existing lint behavior and typos like
+ * `{{eq}}` continue to surface as `no-undef`.
+ *
+ * The probe is cached for the lifetime of the process so this is cheap
+ * to call from per-node scope registration.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isEmber71BuiltInKeyword(name) {
+  if (!EMBER_71_BUILT_IN_KEYWORDS.has(name)) return false;
+  return isEmber71BuiltInKeywordForVersion(name, resolveEmberSourceVersion());
+}
+
+/**
+ * Test-only: reset the cached `ember-source` version probe.
+ */
+export function _resetEmberSourceVersionCache() {
+  cachedVersion = undefined;
+  cachedVersionResolved = false;
+}

--- a/src/parser/ember71-built-in-keywords.js
+++ b/src/parser/ember71-built-in-keywords.js
@@ -92,3 +92,14 @@ export function _resetEmberSourceVersionCache() {
   cachedVersion = undefined;
   cachedVersionResolved = false;
 }
+
+/**
+ * Test-only: force the resolved `ember-source` version. Pass `undefined`
+ * to clear and fall back to real probing on the next call.
+ *
+ * @param {string | undefined} version
+ */
+export function _setEmberSourceVersionForTesting(version) {
+  cachedVersion = version;
+  cachedVersionResolved = true;
+}

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -118,12 +118,17 @@ function registerPathExpression(node, path, scopeManager) {
   if (node.head.type !== 'VarHead') return;
   const name = node.head.name;
   if (glimmerIsKeyword(name)) return;
+  const { scope, variable } = findVarInParentScopes(scopeManager, path, name) || {};
   // `@glimmer/syntax`'s `isKeyword` table predates the Ember 7.1 built-in
   // keywords (RFCs 389/470/560/561/562/997-1000). When the consumer is on
   // ember-source >= 7.1, treat them as built-ins too so `no-undef` doesn't
   // flag bare references like `{{eq}}` or `{{on "click" handler}}`.
-  if (isEmber71BuiltInKeyword(name)) return;
-  const { scope, variable } = findVarInParentScopes(scopeManager, path, name) || {};
+  //
+  // Only when there is NO local binding — a user-authored
+  // `import { eq } from 'ember-truth-helpers'` (or a `const eq = …`) must
+  // shadow the built-in so the scope reference is registered and the
+  // import is marked as used by `no-unused-vars`.
+  if (!variable && isEmber71BuiltInKeyword(name)) return;
   if (scope) {
     node.head.parent = node;
     registerNodeInScope(node.head, scope, variable);

--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { Preprocessor } from 'content-tag';
 import { isKeyword as glimmerIsKeyword } from '@glimmer/syntax';
 import { glimmerVisitorKeys } from 'ember-estree';
+import { isEmber71BuiltInKeyword } from './ember71-built-in-keywords.js';
 import { Reference, Scope, Variable, Definition } from 'eslint-scope';
 import htmlTags from 'html-tags';
 import svgTags from 'svg-tags';
@@ -117,6 +118,11 @@ function registerPathExpression(node, path, scopeManager) {
   if (node.head.type !== 'VarHead') return;
   const name = node.head.name;
   if (glimmerIsKeyword(name)) return;
+  // `@glimmer/syntax`'s `isKeyword` table predates the Ember 7.1 built-in
+  // keywords (RFCs 389/470/560/561/562/997-1000). When the consumer is on
+  // ember-source >= 7.1, treat them as built-ins too so `no-undef` doesn't
+  // flag bare references like `{{eq}}` or `{{on "click" handler}}`.
+  if (isEmber71BuiltInKeyword(name)) return;
   const { scope, variable } = findVarInParentScopes(scopeManager, path, name) || {};
   if (scope) {
     node.head.parent = node;

--- a/tests/ember71-built-in-keywords-parser.test.js
+++ b/tests/ember71-built-in-keywords-parser.test.js
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+import {
+  _resetEmberSourceVersionCache,
+  _setEmberSourceVersionForTesting,
+} from '../src/parser/ember71-built-in-keywords.js';
+
+/**
+ * End-to-end tests for the Ember 7.1 built-in template keyword bail-out
+ * inside `registerPathExpression`. We force the resolved ember-source
+ * version so the tests don't depend on having `ember-source` installed
+ * in this repo, and we drive ESLint's `no-undef` and `no-unused-vars`
+ * rules against the parser output because that's the user-visible
+ * behavior we care about:
+ *
+ *   - bare `{{eq}}` must not be flagged as `no-undef` on >= 7.1
+ *   - `import { eq } from '…'` must still be marked as used by
+ *     `no-unused-vars` (the local binding shadows the built-in)
+ *   - bare `{{eq}}` must STILL be flagged as `no-undef` on < 7.1 or
+ *     when ember-source is unresolvable, so typos still surface.
+ */
+describe('parser — Ember 7.1 built-in template keywords (lint behavior)', () => {
+  /** @type {Linter} */
+  let linter;
+  const PARSER_NAME = 'gjs-parser';
+
+  beforeEach(() => {
+    linter = new Linter();
+    linter.defineParser(PARSER_NAME, { parseForESLint });
+  });
+
+  function lint(code) {
+    return linter.verify(
+      code,
+      {
+        parser: PARSER_NAME,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+        rules: { 'no-undef': 'error', 'no-unused-vars': 'error' },
+      },
+      { filename: 'fixture.gjs' }
+    );
+  }
+
+  describe('with ember-source >= 7.1 resolvable', () => {
+    beforeEach(() => _setEmberSourceVersionForTesting('7.1.0'));
+    afterEach(() => _resetEmberSourceVersionCache());
+
+    it('does not flag a bare 7.1 keyword as no-undef', () => {
+      const messages = lint(['<template>', '  {{eq 1 2}}', '</template>'].join('\n'));
+      expect(messages.filter((m) => m.ruleId === 'no-undef')).toEqual([]);
+    });
+
+    it('does not flag a user import of a 7.1 keyword as no-unused-vars (shadows the built-in)', () => {
+      const messages = lint(
+        [
+          "import { eq } from 'ember-truth-helpers';",
+          '',
+          'export default <template>',
+          '  {{eq 1 2}}',
+          '</template>;',
+        ].join('\n')
+      );
+      expect(messages.filter((m) => m.ruleId === 'no-unused-vars')).toEqual([]);
+      expect(messages.filter((m) => m.ruleId === 'no-undef')).toEqual([]);
+    });
+
+    it('still flags an unrelated free identifier as no-undef', () => {
+      const messages = lint(['<template>', '  {{notDefinedAnywhere}}', '</template>'].join('\n'));
+      const undefMessages = messages.filter((m) => m.ruleId === 'no-undef');
+      expect(undefMessages).toHaveLength(1);
+      expect(undefMessages[0].message).toMatch(/notDefinedAnywhere/);
+    });
+  });
+
+  describe('with ember-source older than 7.1', () => {
+    beforeEach(() => _setEmberSourceVersionForTesting('7.0.5'));
+    afterEach(() => _resetEmberSourceVersionCache());
+
+    it('flags a bare 7.1 keyword as no-undef', () => {
+      const messages = lint(['<template>', '  {{eq 1 2}}', '</template>'].join('\n'));
+      const undefMessages = messages.filter((m) => m.ruleId === 'no-undef');
+      expect(undefMessages).toHaveLength(1);
+      expect(undefMessages[0].message).toMatch(/eq/);
+    });
+  });
+
+  describe('with ember-source unresolvable', () => {
+    beforeEach(() => _setEmberSourceVersionForTesting(undefined));
+    afterEach(() => _resetEmberSourceVersionCache());
+
+    it('flags a bare 7.1 keyword as no-undef', () => {
+      const messages = lint(['<template>', '  {{eq 1 2}}', '</template>'].join('\n'));
+      const undefMessages = messages.filter((m) => m.ruleId === 'no-undef');
+      expect(undefMessages).toHaveLength(1);
+      expect(undefMessages[0].message).toMatch(/eq/);
+    });
+  });
+});

--- a/tests/ember71-built-in-keywords.test.js
+++ b/tests/ember71-built-in-keywords.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMBER_71_BUILT_IN_KEYWORDS,
+  isEmber71BuiltInKeywordForVersion,
+} from '../src/parser/ember71-built-in-keywords.js';
+
+describe('isEmber71BuiltInKeywordForVersion', () => {
+  const NAMES = [
+    'and',
+    'array',
+    'element',
+    'eq',
+    'fn',
+    'gt',
+    'gte',
+    'hash',
+    'lt',
+    'lte',
+    'neq',
+    'not',
+    'on',
+    'or',
+  ];
+
+  it('exposes the 14 Ember 7.1 keywords', () => {
+    expect(EMBER_71_BUILT_IN_KEYWORDS).toEqual(new Set(NAMES));
+  });
+
+  it.each(NAMES)('treats %s as a built-in on 7.1.0', (name) => {
+    expect(isEmber71BuiltInKeywordForVersion(name, '7.1.0')).toBe(true);
+  });
+
+  it('treats keywords as built-ins on a 7.1 prerelease', () => {
+    expect(isEmber71BuiltInKeywordForVersion('eq', '7.1.0-beta.1')).toBe(true);
+  });
+
+  it('treats keywords as built-ins on a 7.x release > 7.1', () => {
+    expect(isEmber71BuiltInKeywordForVersion('eq', '7.2.0')).toBe(true);
+  });
+
+  it('treats keywords as built-ins on a future major', () => {
+    expect(isEmber71BuiltInKeywordForVersion('on', '8.0.0-beta.1')).toBe(true);
+  });
+
+  it.each(['7.0.5', '6.4.0', '5.0.0'])('does not treat keywords as built-ins on %s', (version) => {
+    expect(isEmber71BuiltInKeywordForVersion('eq', version)).toBe(false);
+  });
+
+  it('returns false when the version is missing', () => {
+    expect(isEmber71BuiltInKeywordForVersion('eq', undefined)).toBe(false);
+    expect(isEmber71BuiltInKeywordForVersion('eq', null)).toBe(false);
+  });
+
+  it('returns false for names outside the 7.1 keyword set', () => {
+    expect(isEmber71BuiltInKeywordForVersion('myHelper', '7.1.0')).toBe(false);
+    expect(isEmber71BuiltInKeywordForVersion('component', '7.1.0')).toBe(false);
+  });
+});


### PR DESCRIPTION
ember-source 7.1 ships 14 built-in template keywords (and, array, element, eq, fn, gt, gte, hash, lt, lte, neq, not, on, or) that can be referenced in strict-mode templates without an explicit import. @glimmer/syntax's isKeyword table predates these, so registerPathExpression was lifting them into JS scope and ESLint's no-undef would flag bare references like {{eq}} or {{on "click" handler}}.

Add a small helper that gates on the consumer's resolved ember-source version (>=7.1) and bails out of scope registration for the 14 names. Pre-7.1 projects keep their existing behaviour, so typos still surface as no-undef. The version probe is wrapped in try/catch and cached, so per-identifier cost is a Set lookup.