### PR TITLE
Fix .gts extension rewrite in re-exports (export ... from './foo.gts')

### DIFF
--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -84,7 +84,10 @@ try {
     const length = jsCode.length;
     function visit(node) {
       if (
-        node.kind === ts.SyntaxKind.ImportDeclaration &&
+        (node.kind === ts.SyntaxKind.ImportDeclaration ||
+          node.kind === ts.SyntaxKind.ExportDeclaration) &&
+        node.moduleSpecifier &&
+        node.moduleSpecifier.text &&
         node.moduleSpecifier.text.endsWith('.gts')
       ) {
         const value = node.moduleSpecifier.text.replace(/\.gts$/, '.mts');

--- a/test-projects/configs/flat-ts/src/re-export-consumer.ts
+++ b/test-projects/configs/flat-ts/src/re-export-consumer.ts
@@ -1,0 +1,14 @@
+import { targetFn } from './re-export-via-ts.ts';
+
+// Smoke test for ember-cli/eslint-plugin-ember#2791.
+//
+// `re-export-via-ts.ts` re-exports a symbol from `re-export-target.gts`.
+// Before the fix in `ts-patch.js`, `replaceExtensions` only rewrote
+// `.gts` -> `.mts` in `ImportDeclaration` / dynamic `import()` nodes, so
+// the `export { ... } from './foo.gts'` was left untouched and
+// TypeScript's projectService could not resolve the transitive
+// re-export. `targetFn` would be typed as `any` here, tripping
+// `@typescript-eslint/no-unsafe-call`.
+const value: number = targetFn();
+
+export { value };

--- a/test-projects/configs/flat-ts/src/re-export-target.gts
+++ b/test-projects/configs/flat-ts/src/re-export-target.gts
@@ -1,0 +1,3 @@
+export function targetFn(): number {
+  return 1;
+}

--- a/test-projects/configs/flat-ts/src/re-export-via-ts.ts
+++ b/test-projects/configs/flat-ts/src/re-export-via-ts.ts
@@ -1,0 +1,1 @@
+export { targetFn } from './re-export-target.gts';

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2492,4 +2492,28 @@ describe('replaceExtensions', () => {
       `// description — with em-dash\nimport type { Foo } from './other-component.mts';`
     );
   });
+
+  it('replaces .gts extension in re-exports', () => {
+    const code = `export { one } from './one.gts';`;
+    const result = replaceExtensions(code);
+    expect(result).toBe(`export { one } from './one.mts';`);
+  });
+
+  it('replaces .gts extension in `export *` re-exports', () => {
+    const code = `export * from './one.gts';`;
+    const result = replaceExtensions(code);
+    expect(result).toBe(`export * from './one.mts';`);
+  });
+
+  it('replaces .gts extension in `export type` re-exports', () => {
+    const code = `export type { Foo } from './one.gts';`;
+    const result = replaceExtensions(code);
+    expect(result).toBe(`export type { Foo } from './one.mts';`);
+  });
+
+  it('does not touch local `export {}` declarations without a module specifier', () => {
+    const code = `const one = 1;\nexport { one };`;
+    const result = replaceExtensions(code);
+    expect(result).toBe(code);
+  });
 });


### PR DESCRIPTION
## Summary

`replaceExtensions` (in `src/parser/ts-patch.js`) rewrites `.gts` import
specifiers to `.mts` so the patched `ts.sys.readFile` / `fileExists` can
serve a `.gts` file's transformed content back to TypeScript's
projectService under an `.mts` filename.

The visitor only matched `ImportDeclaration` and dynamic `import()`
calls. `ExportDeclaration` nodes — `export { x } from './foo.gts'`,
`export * from './foo.gts'`, `export type { X } from './foo.gts'` —
were silently skipped, so TS module resolution failed for them and any
type-aware lint rule (`@typescript-eslint/no-unsafe-call`, etc.) saw
`any` for re-exported symbols.

This shows up the moment a `.ts` file re-exports from a `.gts` file and
something else imports through it — exactly the case in
ef4/glint-eslint-bug.

## Test plan

- [x] Added 4 new unit tests covering `export { } from`, `export *`,
  `export type { } from`, and a guard that local `export { name }` (no
  module specifier) is untouched
- [x] Existing `replaceExtensions` tests still pass (`pnpm test`: 85
  pass, was 81)
- [x] Verified against the reproduction repo in
  ember-cli/eslint-plugin-ember#2791 — `pnpm lint:js` is clean with the
  fix and reproduces the error without it

Fixes the root cause of ember-cli/eslint-plugin-ember#2791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)