### PR TITLE
fix package lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "git@github.com:ember-tooling/ember-eslint-parser.git"
+    "url": "git+https://github.com/ember-tooling/ember-eslint-parser.git"
   },
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
fixes:

```
[lint:package] Warnings:
[lint:package] 1. pkg.repository.url is git@github.com:ember-tooling/ember-eslint-parser.git which isn't a valid git URL. A valid git URL is usually in the form of "git+https://example.com/user/repo.git".
```