### PR TITLE
Match transformForLint masking to ember-estree's toPlaceholderJS (fixes per-file program rebuilds)

### DIFF
--- a/src/parser/transforms.js
+++ b/src/parser/transforms.js
@@ -279,8 +279,11 @@ export const replaceRange = function replaceRange(s, start, end, substitute) {
 };
 
 function maskTemplateContentForLint(content) {
-  // Preserve line endings and UTF-16 length, but remove template syntax from the JS placeholder.
-  return content.replace(/[^\r\n]/g, ' ');
+  // Must produce byte-identical output to ember-estree's toPlaceholderJS
+  // masking, or typescript-eslint sees two different contents for the same
+  // .gts file (disk read vs lint parse) and invalidates + rebuilds the
+  // program on every file.
+  return content.replace(/[`$]/g, ' ');
 }
 
 const processor = new Preprocessor();

--- a/tests/placeholder-parity.test.js
+++ b/tests/placeholder-parity.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { toTree } from 'ember-estree';
+import { transformForLint } from '../src/parser/transforms.js';
+
+/**
+ * transformForLint (used by the patched ts.sys.readFile for type-aware
+ * linting) must produce byte-identical output to the placeholder JS that
+ * ember-estree's toTree hands to the JS/TS parser at lint time.
+ *
+ * typescript-eslint hashes the code passed to parseForESLint and compares it
+ * against what the watch program last read off disk; any difference marks the
+ * file as changed and silently rebuilds the whole program inside
+ * getProgram() — once per .gts/.gjs file linted (#229).
+ */
+
+function toTreePlaceholder(code) {
+  let placeholder;
+  try {
+    toTree(code, {
+      filePath: 'x.gts',
+      parser: (js) => {
+        placeholder = js;
+        // Only the placeholder is needed; abort before JS parsing.
+        throw new Error('stop');
+      },
+    });
+  } catch {
+    // expected
+  }
+  return placeholder;
+}
+
+const cases = {
+  'backtick-heavy template comments (#226)': `import Component from '@glimmer/component';
+
+export default class MyComponent extends Component {
+  <template>
+    {{!  \`asd\` \`qwe\` \`zxc\` \`undefined\` \`asd\` }}
+    {{! \`@foo\` }}
+  </template>
+}
+`,
+  'expression template with dollar signs': `export const x = <template>costs \${{amount}} \`really\` $$$</template>;
+`,
+  'multibyte content (emoji, CJK)': `export const y = <template>🎉 日本語 \` $ 🚀</template>;
+`,
+  'CRLF line endings': `export const z = <template>\r\n  hi \`there\`\r\n</template>;\r\n`,
+  'multiple templates in one module': `export const a = <template>one \`x\`</template>;
+export const b = <template>two $y</template>;
+`,
+};
+
+describe('transformForLint matches toTree placeholder byte-for-byte', () => {
+  for (const [name, code] of Object.entries(cases)) {
+    it(name, () => {
+      expect(transformForLint(code).output).toBe(toTreePlaceholder(code));
+    });
+  }
+});


### PR DESCRIPTION
Fixes #229 (the performance/memory half, with a strong lead on the rest).

## Root cause

For type-aware linting, every `.gts`/`.gjs` file gets a JS placeholder text twice, by two different implementations:

- **Lint time**: ember-estree's `toPlaceholderJS` keeps template content and blanks only `` ` ``/`$` (since ember-estree 0.6.10, the #230 fix)
- **Program build time**: `transformForLint` in the patched `ts.sys.readFile` blanked **every** non-newline character (since v0.14.1, the #226 fix)

typescript-estree hashes the code passed to `parseForESLint` against what the watch program last read from disk (`getWatchProgramsForProjects`). Since the two maskings differ, every file with a non-empty template hashes differently — which fires the file-changed watch callback and **silently rebuilds the entire TS program inside `getProgram()`, once per `.gts`/`.gjs` file linted**. It's invisible in debug logs ("Found existing program for file" prints either way); the tell is that `services.program` is a new object on every parse.

On a large codebase that's an O(project) rebuild × thousands of files — hour-long runs — and the allocation churn (× `--concurrency` workers) accounts for the tens-of-GB memory. It also plausibly feeds the non-deterministic type errors, since checker state now depends on per-worker lint order.

### How the two fixes diverged

#226 and #230 were the same escape-overflow bug in the two copies of this logic. Through v0.14.0 both sides *escaped* `` ` ``/`$` identically, so bytes matched except on overflow files. The fixes chose different maskings (blank-all vs blank-`` `$ ``), so as of v0.14.1/v0.14.2 *every* templated file mismatches.

## Fix

Blank only `` ` ``/`$` in `maskTemplateContentForLint`, byte-matching ember-estree 0.6.10. This remains overflow-safe for the #226 case (1:1 replacement, placeholder never outgrows the region).

Verified against a minimal 3-file typed-lint project: before, `services.program` was a distinct object after every parse; after, all parses share one program.

## Regression test

`tests/placeholder-parity.test.js` asserts `transformForLint(code).output` is byte-identical to the `toTree` placeholder across the #226 snippet, dollar-heavy expression templates, emoji/CJK, CRLF, and multi-template modules — so the two implementations can't silently drift again. Longer-term it may be worth exporting `toPlaceholderJS` from ember-estree and deleting the copy here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)