### PR TITLE
Graft .gts SourceFiles onto every virtual twin, once per program

### DIFF
--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -116,10 +116,31 @@ try {
   };
 
   /**
+   * Graft each real `.gts`/`.gjs` SourceFile onto its virtual twins so every
+   * import path yields the same AST nodes, and therefore the same type
+   * identity. A program can hold up to three copies of one templated file:
+   * the `.gts` root itself, the `.mts` twin injected via readDirectory (the
+   * target of explicit `import './x.gts'` specifiers, which
+   * replaceExtensions rewrites to `.mts`), and a `.ts` virtual created when
+   * another file resolves an extensionless `import './x'` through the
+   * patched fileExists. Distinct copies mean distinct class symbols — a
+   * class with a private member is then not assignable to itself across
+   * paths, unions of the "same" type don't dedupe, and typed rules
+   * (`no-unnecessary-type-assertion`, `no-redundant-type-constituents`)
+   * report order-dependent false positives (#229).
+   *
+   * Runs once per program: the graft mutates SourceFiles, so repeating it
+   * after every parse rewrites binder state (symbol/locals) under a live
+   * type checker — stale symbols stay cached and results become
+   * lint-order dependent. It also walks the whole file list, which is
+   * O(program files) per linted file.
    *
    * @param program {ts.Program}
    */
+  const syncedPrograms = new WeakSet();
   syncMtsGtsSourceFiles = function syncMtsGtsSourceFiles(program) {
+    if (syncedPrograms.has(program)) return;
+    syncedPrograms.add(program);
     const sourceFiles = program.getSourceFiles();
     function syncVirtualFile(sourceFile, ext, virtualExt, virtualFlag) {
       // check for deleted files, need to remove virtual as well
@@ -132,15 +153,15 @@ try {
         }
       }
       if (sourceFile.path.endsWith(`.${ext}`)) {
-        let virtualSourceFile = program.getSourceFile(
-          sourceFile.path.replace(new RegExp(`\\.${ext}$`), `.${virtualExt}`)
-        );
-        if (!virtualSourceFile) {
-          virtualSourceFile = program.getSourceFile(
+        const virtualSourceFiles = [
+          program.getSourceFile(
+            sourceFile.path.replace(new RegExp(`\\.${ext}$`), `.${virtualExt}`)
+          ),
+          program.getSourceFile(
             sourceFile.path.replace(new RegExp(`\\.${ext}$`), virtualExt === 'mts' ? '.ts' : '.js')
-          );
-        }
-        if (virtualSourceFile) {
+          ),
+        ].filter(Boolean);
+        for (const virtualSourceFile of virtualSourceFiles) {
           const keep = {
             fileName: virtualSourceFile.fileName,
             path: virtualSourceFile.path,

--- a/tests/fixtures/type-identity/consumer.ts
+++ b/tests/fixtures/type-identity/consumer.ts
@@ -1,0 +1,5 @@
+import Priv from './priv';
+
+export function take(p: Priv): Priv {
+  return p;
+}

--- a/tests/fixtures/type-identity/other.gts
+++ b/tests/fixtures/type-identity/other.gts
@@ -1,0 +1,6 @@
+import Priv from './priv';
+
+export default class Other {
+  prop: Priv | null = null;
+  <template>{{this.prop}}</template>
+}

--- a/tests/fixtures/type-identity/priv.gts
+++ b/tests/fixtures/type-identity/priv.gts
@@ -1,0 +1,7 @@
+export default class Priv {
+  #secret = 1;
+  get val(): number {
+    return this.#secret;
+  }
+  <template>{{this.val}}</template>
+}

--- a/tests/fixtures/type-identity/tsconfig.json
+++ b/tests/fixtures/type-identity/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "**/*.gts"]
+}

--- a/tests/virtual-twin-type-identity.test.js
+++ b/tests/virtual-twin-type-identity.test.js
@@ -1,0 +1,129 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parseForESLint } from '../src/parser/gjs-gts-parser.js';
+
+/**
+ * A project-mode program can hold one templated file under several paths:
+ * the `.gts` root, a `.ts` virtual created when another file resolves
+ * `import './x'` extensionless through the patched fileExists, and — on
+ * newer typescript-eslint/TypeScript versions — a `.mts` twin injected as a
+ * root via the patched readDirectory. If a copy keeps its own AST it gets
+ * its own class symbols, so a class with a private member is not assignable
+ * to itself across import paths — the source of the order-dependent false
+ * positives in typed rules reported in #229
+ * (`no-unnecessary-type-assertion`, `no-redundant-type-constituents`).
+ *
+ * syncMtsGtsSourceFiles must graft the real SourceFile onto EVERY virtual
+ * twin present (not just the first found), and must do so only once per
+ * program — re-grafting after later parses rewrites binder state under a
+ * live type checker.
+ *
+ * The suite runs under both `project` and `projectService`, the two ways
+ * typed linting obtains a program. projectService is feature-detected: its
+ * option spelling varies across typescript-eslint majors, and v7's
+ * experimental service can't hold `.gts` files in-project (the resulting
+ * default-project program has no virtual twins, leaving nothing to graft).
+ */
+
+const fixtureDir = path.join(import.meta.dirname, 'fixtures', 'type-identity');
+const privPath = path.join(fixtureDir, 'priv.gts');
+const otherPath = path.join(fixtureDir, 'other.gts');
+
+function parseWith(modeOptions, filePath) {
+  return parseForESLint(fs.readFileSync(filePath, 'utf8'), {
+    filePath,
+    ...modeOptions,
+    tsconfigRootDir: fixtureDir,
+    extraFileExtensions: ['.gts', '.gjs'],
+    loc: true,
+    range: true,
+    tokens: true,
+    comment: true,
+    sourceType: 'module',
+  });
+}
+
+function virtualTwinsOf(program, gtsPath) {
+  return [
+    program.getSourceFile(gtsPath.replace(/\.gts$/, '.mts')),
+    program.getSourceFile(gtsPath.replace(/\.gts$/, '.ts')),
+  ].filter(Boolean);
+}
+
+const MODES = [['project', { project: './tsconfig.json' }]];
+
+for (const options of [{ projectService: true }, { EXPERIMENTAL_useProjectService: true }]) {
+  try {
+    const program = parseWith(options, privPath).services?.program;
+    if (program?.getSourceFile(privPath) && virtualTwinsOf(program, privPath).length > 0) {
+      MODES.push(['projectService', options]);
+      break;
+    }
+  } catch {
+    // spelling unsupported by the installed @typescript-eslint/parser
+  }
+}
+
+for (const [modeName, modeOptions] of MODES) {
+  const parse = (filePath) => parseWith(modeOptions, filePath);
+
+  describe(`virtual twin type identity (#229) — ${modeName}`, () => {
+    it('grafts the real .gts SourceFile onto every virtual twin in the program', () => {
+      const result = parse(privPath);
+      const program = result.services.program;
+
+      const gts = program.getSourceFile(privPath);
+      expect(gts).toBeTruthy();
+
+      // consumer.ts imports './priv' extensionless, so at minimum the
+      // resolver-created .ts virtual exists; depending on the TS version a
+      // readDirectory-injected .mts twin exists as well.
+      const twins = virtualTwinsOf(program, privPath);
+      expect(twins.length).toBeGreaterThanOrEqual(1);
+
+      for (const twin of twins) {
+        expect(twin.statements).toBe(gts.statements);
+        expect(twin.isVirtualGts).toBe(true);
+      }
+    });
+
+    it('a private-member class has one type identity across import paths', () => {
+      const result = parse(privPath);
+      const program = result.services.program;
+      const checker = program.getTypeChecker();
+
+      const gts = program.getSourceFile(privPath);
+      const classOf = (sf) => sf.statements.find((s) => s.name?.escapedText === 'Priv');
+      const typeOf = (sf) =>
+        checker.getDeclaredTypeOfSymbol(checker.getSymbolAtLocation(classOf(sf).name));
+
+      const gtsType = typeOf(gts);
+      for (const twin of virtualTwinsOf(program, privPath)) {
+        const twinType = typeOf(twin);
+        // Identical, not merely mutually assignable: statements are shared,
+        // so both paths reach the same class declaration node.
+        expect(twinType).toBe(gtsType);
+        expect(checker.isTypeAssignableTo(gtsType, twinType)).toBe(true);
+        expect(checker.isTypeAssignableTo(twinType, gtsType)).toBe(true);
+      }
+    });
+
+    it('does not re-graft an already-synced program on later parses', () => {
+      const first = parse(privPath);
+      const program = first.services.program;
+
+      const [twin] = virtualTwinsOf(program, privPath);
+      expect(twin).toBeTruthy();
+      // Bind, then plant a canary where the graft writes its marker flag. A
+      // re-graft on the next parse would overwrite it (and with it, live
+      // binder state such as symbol/locals — the #229 non-determinism vector).
+      program.getTypeChecker().getSymbolAtLocation(twin);
+      twin.isVirtualGts = 'already-synced-canary';
+
+      const second = parse(otherPath);
+      expect(second.services.program).toBe(program);
+      expect(twin.isVirtualGts).toBe('already-synced-canary');
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #233 for the remaining problems in #229 (non-deterministic typed-rule false positives, memory).

## The bug

A project-mode program can hold one templated file under up to **three paths**:

1. the `.gts` root itself (the linted file),
2. a `.ts` virtual, created when another file resolves an extensionless `import './x'` through the patched `fileExists`,
3. a `.mts` twin injected as a root via the patched `readDirectory` (the target `replaceExtensions` rewrites explicit `import './x.gts'` specifiers to).

`syncMtsGtsSourceFiles` grafted the real SourceFile onto only the **first** twin it found, preferring `.mts`. On older TS/typescript-eslint versions the `.mts` twin doesn't end up in the program, the fallback fires, and the `.ts` virtual gets grafted — everything works. On current versions (verified with typescript-eslint 8.62.1 + TypeScript 6.0.3) the `.mts` root **does** exist, so the graft lands on a file nothing imports, while the `.ts` virtual — the copy every extensionless import actually resolves to — keeps its own independent AST.

Two ASTs for the same class means two class symbols. TypeScript compares private members nominally, so the class becomes **not assignable to itself** across import paths ("Type 'Foo' is not assignable to type 'Foo'"), unions of the "same" type don't dedupe, and typed rules like `no-unnecessary-type-assertion` / `no-redundant-type-constituents` produce false positives that depend on which path a cached type was first reached through — i.e. on lint order, which varies run-to-run with concurrency. Verified in an isolated repro: `checker.isTypeAssignableTo(gtsType, tsVirtualType)` is `false` both ways for a class with a private member on 0.14.3, `true` (identical type objects) with this patch.

## The second bug

The graft also ran **after every parse**, re-walking the entire program file list (O(program files) per linted file) and re-copying binder state (`symbol`, `locals`) onto twins while a live type checker holds references to the previous symbols — stale symbols stay cached, fresh ones appear for new queries, and results become lint-order dependent. The graft is only needed once per program, so it now runs behind a `WeakSet` guard (a rebuilt program is a new object and gets re-grafted).

## Measurements (400 synthetic gts + 800 ts files, typed queries on every identifier)

| variant | round 1 | round 2 | heap |
|---|---|---|---|
| no graft (3 unshared ASTs/file) | 6.1s | 2.0s | 134.8MB |
| graft all twins, every parse | 8.9s | 5.0s | 120.1MB |
| graft all twins, once per program (this PR) | 5.9s | 2.2s | 120.0MB |

Sharing statements across twins also drops the duplicate ASTs (~11% heap on tiny synthetic files; real components should save proportionally more).

## Tests

`tests/virtual-twin-type-identity.test.js`, run under both `project` and `projectService` (feature-detected; 3 tests on tsee 7, 6 on tsee 8). #240 demonstrated them failing against the unfixed parser on CI:
- every virtual twin present shares `statements` with the `.gts` root,
- a private-member class has one type identity (identical type objects, assignable both ways) across import paths,
- an already-synced program is not re-grafted on later parses.

## What this should fix for #229

The order-dependent false positives from typed rules, plus a slice of time/memory. The inherent cost — one full TS program per concurrent worker — remains; that part is expected for typed linting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

