### PR TITLE
Add project-mode benchmark and run it in the benchmark comparison workflow

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -28,20 +28,30 @@ jobs:
 
       - uses: wyvox/action-setup-pnpm@v4
 
-      - name: Run benchmark comparison
+      - name: Run benchmark comparison (parse)
         env:
           BENCH_JSON_OUTPUT: ${{ runner.temp }}/bench-results.json
         run: |
           set -o pipefail
           pnpm bench:compare | sed 's/\x1b\[[0-9;]*m//g' > "$RUNNER_TEMP/bench-output.txt"
 
+      - name: Run benchmark comparison (project mode)
+        if: always() && steps.checkout.outcome == 'success'
+        env:
+          BENCH_JSON_OUTPUT: ${{ runner.temp }}/project-bench-results.json
+        run: |
+          set -o pipefail
+          pnpm bench:project:compare | sed 's/\x1b\[[0-9;]*m//g' > "$RUNNER_TEMP/project-bench-output.txt"
+
       - name: Format PR comment
         if: always() && steps.checkout.outcome == 'success'
         env:
-          BENCH_OUTPUT_FILE: ${{ runner.temp }}/bench-output.txt
-          BENCH_JSON_OUTPUT: ${{ runner.temp }}/bench-results.json
           BENCH_JOB_SUCCESS: ${{ job.status == 'success' }}
-        run: node scripts/format-bench-comment.mjs > "$RUNNER_TEMP/bench-comment.md"
+        run: |
+          node scripts/format-bench-comment.mjs \
+            --section "Parse" "$RUNNER_TEMP/bench-output.txt" "$RUNNER_TEMP/bench-results.json" \
+            --section "Project mode (type-aware)" "$RUNNER_TEMP/project-bench-output.txt" "$RUNNER_TEMP/project-bench-results.json" \
+            > "$RUNNER_TEMP/bench-comment.md"
 
       - name: Write job summary
         if: always() && steps.checkout.outcome == 'success'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "scripts": {
     "bench": "./scripts/run-bench.sh tests/parser.bench.mjs",
     "bench:compare": "node scripts/bench-compare.mjs",
+    "bench:project": "./scripts/run-bench.sh tests/project.bench.mjs",
+    "bench:project:compare": "node scripts/bench-compare.mjs --bench tests/project.bench.mjs",
     "bench:summary": "./scripts/local-bench-summary.sh",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",

--- a/scripts/bench-compare.mjs
+++ b/scripts/bench-compare.mjs
@@ -9,10 +9,11 @@
  * summary tables and boxplots.
  *
  * Usage:
- *   node scripts/bench-compare.mjs [--base <branch>]
+ *   node scripts/bench-compare.mjs [--base <branch>] [--bench <script>]
  *
  * Options:
  *   --base <branch>   Branch to compare against (default: main)
+ *   --bench <script>  Bench script to run (default: tests/parser.bench.mjs)
  */
 
 import { execSync, spawnSync } from 'node:child_process';
@@ -27,6 +28,8 @@ import { join } from 'node:path';
 const args = process.argv.slice(2);
 const baseIdx = args.indexOf('--base');
 const BASE_BRANCH = baseIdx !== -1 ? args[baseIdx + 1] : 'main';
+const benchIdx = args.indexOf('--bench');
+const BENCH_SCRIPT = benchIdx !== -1 ? args[benchIdx + 1] : 'tests/parser.bench.mjs';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -96,7 +99,7 @@ try {
   // ── 3. Run mitata bench with --control-dir ───────────────────────────────
   console.error(`\n🏎️  Running benchmarks (experiment vs control)…\n`);
 
-  const benchScript = join(ROOT, 'tests/parser.bench.mjs');
+  const benchScript = join(ROOT, BENCH_SCRIPT);
   const benchArgs = [
     '--expose-gc',
     '--max-old-space-size=4096',

--- a/scripts/format-bench-comment.mjs
+++ b/scripts/format-bench-comment.mjs
@@ -2,13 +2,22 @@
  * Format benchmark comparison results into a GitHub PR comment.
  *
  * Reads the plain-text mitata output and (optionally) the JSON results from
- * the bench run, then produces a GitHub-flavored markdown comment with:
+ * one or more bench runs, then produces a GitHub-flavored markdown comment
+ * with, per bench:
  *   1. A summary table (when comparison data is available)
  *   2. Full mitata output in a collapsible <details> section
  *
- * Environment variables:
+ * Sections can be passed as repeated CLI triples:
+ *   node scripts/format-bench-comment.mjs \
+ *     --section "Parse" bench-output.txt bench-results.json \
+ *     --section "Project mode" project-output.txt project-results.json
+ *
+ * With no --section args, a single unlabelled section is read from the
+ * environment (the original interface):
  *   BENCH_OUTPUT_FILE   - Path to the plain-text bench output
  *   BENCH_JSON_OUTPUT   - Path to the JSON bench results (optional)
+ *
+ * Environment variables:
  *   BENCH_JOB_SUCCESS   - Set to "true" if the benchmark job succeeded
  */
 
@@ -18,54 +27,83 @@ import { formatTime, deltaEmoji, parsePairs, readBenchJSON } from './bench-utils
 const marker = '<!-- bench-compare -->';
 
 // ---------------------------------------------------------------------------
-// Read raw mitata output
+// Collect sections
 // ---------------------------------------------------------------------------
 
-let rawOutput;
-try {
-  rawOutput = readFileSync(process.env.BENCH_OUTPUT_FILE, 'utf8').trim();
-} catch {
-  console.warn('Warning: could not read BENCH_OUTPUT_FILE; using placeholder text.');
-  rawOutput = '(no output — benchmark may have failed to start)';
-}
-
-// Strip any lines before the mitata header (safety net for leaked setup messages)
-const benchStart = rawOutput.search(/^(clk:|benchmark\b)/m);
-if (benchStart > 0) {
-  rawOutput = rawOutput.slice(benchStart);
-}
-
-// ---------------------------------------------------------------------------
-// Read JSON results (if available) and build summary
-// ---------------------------------------------------------------------------
-
-let summarySection = '';
-const jsonPath = process.env.BENCH_JSON_OUTPUT;
-
-if (jsonPath) {
-  try {
-    const rows = parsePairs(readBenchJSON(jsonPath));
-
-    if (rows.length > 0) {
-      const tableRows = rows.map(({ name, control, experiment, delta }) => {
-        const emoji = deltaEmoji(delta);
-        const sign = delta > 0 ? '+' : '';
-        return `| ${emoji} | ${name} | ${formatTime(control)} | ${formatTime(experiment)} | ${sign}${delta.toFixed(1)}% |`;
-      });
-
-      summarySection = [
-        '',
-        '| | Benchmark | Control (p50) | Experiment (p50) | Δ |',
-        '|---|---|---:|---:|---:|',
-        ...tableRows,
-        '',
-        '> 🟢 faster · 🔴 slower · 🟠 slightly slower · ⚪ within 2%',
-        '',
-      ].join('\n');
-    }
-  } catch {
-    // JSON not available or malformed — skip summary
+const args = process.argv.slice(2);
+const sections = [];
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--section') {
+    sections.push({ title: args[i + 1], outputFile: args[i + 2], jsonFile: args[i + 3] });
+    i += 3;
   }
+}
+if (sections.length === 0) {
+  sections.push({
+    title: null,
+    outputFile: process.env.BENCH_OUTPUT_FILE,
+    jsonFile: process.env.BENCH_JSON_OUTPUT,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Render each section
+// ---------------------------------------------------------------------------
+
+function renderSection({ title, outputFile, jsonFile }) {
+  let rawOutput;
+  try {
+    rawOutput = readFileSync(outputFile, 'utf8').trim();
+  } catch {
+    console.warn(`Warning: could not read bench output ${outputFile}; using placeholder text.`);
+    rawOutput = '(no output — benchmark may have failed to start)';
+  }
+
+  // Strip any lines before the mitata header (safety net for leaked setup messages)
+  const benchStart = rawOutput.search(/^(clk:|benchmark\b)/m);
+  if (benchStart > 0) {
+    rawOutput = rawOutput.slice(benchStart);
+  }
+
+  let summarySection = '';
+  if (jsonFile) {
+    try {
+      const rows = parsePairs(readBenchJSON(jsonFile));
+
+      if (rows.length > 0) {
+        const tableRows = rows.map(({ name, control, experiment, delta }) => {
+          const emoji = deltaEmoji(delta);
+          const sign = delta > 0 ? '+' : '';
+          return `| ${emoji} | ${name} | ${formatTime(control)} | ${formatTime(experiment)} | ${sign}${delta.toFixed(1)}% |`;
+        });
+
+        summarySection = [
+          '',
+          '| | Benchmark | Control (p50) | Experiment (p50) | Δ |',
+          '|---|---|---:|---:|---:|',
+          ...tableRows,
+          '',
+          '> 🟢 faster · 🔴 slower · 🟠 slightly slower · ⚪ within 2%',
+          '',
+        ].join('\n');
+      }
+    } catch {
+      // JSON not available or malformed — skip summary
+    }
+  }
+
+  return [
+    ...(title ? [`### ${title}`, ''] : []),
+    summarySection,
+    '<details>',
+    '<summary>Full mitata output</summary>',
+    '',
+    '```',
+    rawOutput,
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -75,18 +113,6 @@ if (jsonPath) {
 const success = process.env.BENCH_JOB_SUCCESS === 'true';
 const heading = success ? '## 🏎️ Benchmark Comparison' : '## ❌ Benchmark Comparison (failed)';
 
-const body = [
-  marker,
-  heading,
-  summarySection,
-  '<details>',
-  '<summary>Full mitata output</summary>',
-  '',
-  '```',
-  rawOutput,
-  '```',
-  '',
-  '</details>',
-].join('\n');
+const body = [marker, heading, ...sections.map(renderSection)].join('\n');
 
 process.stdout.write(body + '\n');

--- a/tests/project.bench.mjs
+++ b/tests/project.bench.mjs
@@ -259,8 +259,11 @@ globalThis.gc?.();
 // Register benchmarks
 // ---------------------------------------------------------------------------
 
-const PARSES_PER_ITER = 20;
-const TYPED_PER_ITER = 8;
+// Enough work per iteration to stay well above the system-noise floor
+// (aim for hundreds of ms, not tens): short iterations let scheduler jitter
+// and individual GC pauses dominate the measurement.
+const PARSES_PER_ITER = 150;
+const TYPED_PER_ITER = 150;
 
 function makeRoundRobin(step) {
   let cursor = 0;

--- a/tests/project.bench.mjs
+++ b/tests/project.bench.mjs
@@ -301,21 +301,24 @@ for (const mode of MODES) {
 
   for (const scenario of scenarios) {
     globalThis.gc?.();
+    // gc('inner') collects before every iteration: each parse batch churns
+    // hundreds of MB of AST, and without it major-GC pauses land on random
+    // samples — an A/A comparison (identical parsers) read as ±9% otherwise.
     if (control) {
       boxplot(() => {
         summary(() => {
           bench(
             `${scenario.name} (control)`,
             scenario.makeFn(control.parseForESLint, mode.controlOptions ?? mode.options)
-          );
+          ).gc('inner');
           bench(
             `${scenario.name} (experiment)`,
             scenario.makeFn(experiment.parseForESLint, mode.options)
-          );
+          ).gc('inner');
         });
       });
     } else {
-      bench(scenario.name, scenario.makeFn(experiment.parseForESLint, mode.options));
+      bench(scenario.name, scenario.makeFn(experiment.parseForESLint, mode.options)).gc('inner');
     }
   }
 }

--- a/tests/project.bench.mjs
+++ b/tests/project.bench.mjs
@@ -1,0 +1,349 @@
+/* eslint-disable n/no-process-exit */
+/**
+ * Project-mode (type-aware) benchmark using mitata.
+ *
+ * The parse-only benchmarks in parser.bench.mjs never invoke patchTs /
+ * syncMtsGtsSourceFiles — those only run with `project` / `projectService`
+ * parser options. This bench measures the type-aware path: it generates a
+ * synthetic project (N gts components importing each other extensionless,
+ * plus supporting .ts modules), builds the TS program once during warm-up,
+ * then benchmarks warm per-file parses and typed-rule-style checker queries.
+ *
+ * When run standalone (`node --expose-gc tests/project.bench.mjs`), it
+ * benchmarks the local parser only. When `bench-compare.mjs` passes
+ * `--control-dir <dir>`, it also loads the control (base-branch) parser from
+ * that directory for a side-by-side comparison.
+ *
+ * Environment variables:
+ *   BENCH_PROJECT_FILES - number of gts components to generate (default 200)
+ *   BENCH_JSON_OUTPUT   - path to write JSON results
+ *
+ * Usage:
+ *   node --expose-gc tests/project.bench.mjs [--control-dir <path>]
+ */
+
+import { createRequire } from 'node:module';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { run, bench, boxplot, summary, do_not_optimize as doNotOptimize } from 'mitata';
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const ctrlIdx = args.indexOf('--control-dir');
+const CONTROL_DIR = ctrlIdx !== -1 ? resolve(args[ctrlIdx + 1]) : null;
+
+// ---------------------------------------------------------------------------
+// Load parsers
+// ---------------------------------------------------------------------------
+
+const require_ = createRequire(import.meta.url);
+const experiment = require_('../src/parser/gjs-gts-parser.js');
+const control = CONTROL_DIR
+  ? createRequire(resolve(CONTROL_DIR, 'index.js'))('./src/parser/gjs-gts-parser.js')
+  : null;
+
+// ---------------------------------------------------------------------------
+// Generate a synthetic project
+// ---------------------------------------------------------------------------
+
+const N = parseInt(process.env.BENCH_PROJECT_FILES ?? '200', 10);
+const PROJECT_DIR = join(tmpdir(), `eep-project-bench-${process.pid}`);
+const APP_DIR = join(PROJECT_DIR, 'app');
+
+function generateProject() {
+  rmSync(PROJECT_DIR, { recursive: true, force: true });
+  mkdirSync(APP_DIR, { recursive: true });
+
+  writeFileSync(
+    join(PROJECT_DIR, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ['app/**/*'],
+      },
+      null,
+      2
+    )
+  );
+
+  for (let i = 0; i < N; i++) {
+    const next = (i + 1) % N;
+    writeFileSync(
+      join(APP_DIR, `comp${i}.gts`),
+      `import Component from './base${i}';
+import { helper${i} } from './util${i}';
+${i % 2 === 0 ? `import Other from './comp${next}';` : ''}
+
+export interface Sig${i} { Args: { count: number; label?: string } }
+
+export default class Comp${i} extends Component<Sig${i}> {
+  #internal = ${i};
+  get doubled(): number {
+    return helper${i}(this.args.count) * 2 + this.#internal;
+  }
+  get label(): string {
+    return this.args.label ?? 'comp${i}';
+  }
+  <template>
+    <div class="comp${i}">
+      {{this.label}}: {{this.doubled}}
+      {{! template comment with \`backticks\` and $dollars }}
+      ${i % 2 === 0 ? '<Other @count={{this.doubled}} />' : ''}
+      <span data-x="{{this.args.count}}">static text</span>
+    </div>
+  </template>
+}
+`
+    );
+    writeFileSync(
+      join(APP_DIR, `util${i}.ts`),
+      `import type Comp from './comp${i}';
+export function helper${i}(n: number): number { return n + ${i}; }
+export type C${i} = typeof Comp;
+`
+    );
+    writeFileSync(
+      join(APP_DIR, `base${i}.ts`),
+      `export default class Base${i}<S = unknown> { declare args: S extends { Args: infer A } ? A : never; }\n`
+    );
+  }
+}
+
+function cleanup() {
+  if (existsSync(PROJECT_DIR)) {
+    try {
+      rmSync(PROJECT_DIR, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+}
+process.on('exit', cleanup);
+process.on('SIGINT', () => process.exit(130));
+process.on('SIGTERM', () => process.exit(143));
+
+generateProject();
+
+const GTS_FILES = Array.from({ length: N }, (_, i) => join(APP_DIR, `comp${i}.gts`));
+const SOURCES = new Map(GTS_FILES.map((f) => [f, readFileSync(f, 'utf8')]));
+
+// ---------------------------------------------------------------------------
+// Parse options per mode
+// ---------------------------------------------------------------------------
+
+const BASE_OPTIONS = {
+  tsconfigRootDir: PROJECT_DIR,
+  extraFileExtensions: ['.gts', '.gjs'],
+  comment: true,
+  loc: true,
+  range: true,
+  tokens: true,
+  sourceType: 'module',
+};
+
+const MODES = [{ key: 'project', options: { project: './tsconfig.json' } }];
+
+// projectService is spelled differently across typescript-eslint majors and
+// may be absent entirely; feature-detect instead of hardcoding.
+function detectProjectService(parse) {
+  for (const options of [{ projectService: true }, { EXPERIMENTAL_useProjectService: true }]) {
+    try {
+      const filePath = GTS_FILES[0];
+      const result = parse(SOURCES.get(filePath), { ...BASE_OPTIONS, ...options, filePath });
+      if (result.services?.program) return options;
+    } catch {
+      // unsupported spelling — try the next one
+    }
+  }
+  return null;
+}
+
+const serviceOptions = detectProjectService(experiment.parseForESLint);
+const controlServiceOptions = control ? detectProjectService(control.parseForESLint) : null;
+if (serviceOptions && (!control || controlServiceOptions)) {
+  MODES.push({
+    key: 'projectService',
+    options: serviceOptions,
+    controlOptions: controlServiceOptions,
+  });
+} else {
+  console.error(
+    'ℹ️  projectService not supported by installed @typescript-eslint/parser — skipping'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Typed-rule-style checker queries (getTypeAtLocation on every Identifier)
+// ---------------------------------------------------------------------------
+
+function walkIdentifiers(node, cb, seen = new Set()) {
+  if (!node || typeof node.type !== 'string' || seen.has(node)) return;
+  seen.add(node);
+  if (node.type === 'Identifier') cb(node);
+  for (const key of Object.keys(node)) {
+    if (key === 'parent' || key === 'loc' || key === 'range') continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const child of value) walkIdentifiers(child, cb, seen);
+    } else if (value && typeof value === 'object') {
+      walkIdentifiers(value, cb, seen);
+    }
+  }
+}
+
+function parseFile(parse, options, filePath) {
+  return parse(SOURCES.get(filePath), { ...BASE_OPTIONS, ...options, filePath });
+}
+
+function typedQueries(parse, options, filePath) {
+  const result = parseFile(parse, options, filePath);
+  const program = result.services.program;
+  const checker = program.getTypeChecker();
+  const esMap = result.services.esTreeNodeToTSNodeMap;
+  let count = 0;
+  walkIdentifiers(result.ast, (node) => {
+    const tsNode = esMap.get(node);
+    if (tsNode) {
+      doNotOptimize(checker.getTypeAtLocation(tsNode));
+      count++;
+    }
+  });
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Warm-up: build every (parser × mode) program and populate checker caches so
+// the benchmarks measure warm per-file cost, not program construction.
+// ---------------------------------------------------------------------------
+
+console.error(`⏳  Warming up (${N} components, ${MODES.map((m) => m.key).join(', ')})…`);
+for (const mode of [...MODES]) {
+  try {
+    for (const filePath of GTS_FILES) {
+      parseFile(experiment.parseForESLint, mode.options, filePath);
+      control?.parseForESLint &&
+        parseFile(control.parseForESLint, mode.controlOptions ?? mode.options, filePath);
+    }
+    typedQueries(experiment.parseForESLint, mode.options, GTS_FILES[0]);
+    if (control) {
+      typedQueries(control.parseForESLint, mode.controlOptions ?? mode.options, GTS_FILES[0]);
+    }
+  } catch (e) {
+    // e.g. typescript-eslint v7's experimental projectService caps how many
+    // out-of-project files it accepts, and .gts never becomes in-project
+    // there. Drop the mode rather than fail the whole bench.
+    MODES.splice(MODES.indexOf(mode), 1);
+    console.error(`ℹ️  dropping ${mode.key} mode: ${e.message.split('\n')[0]}`);
+  }
+}
+if (MODES.length === 0) {
+  console.error('❌  no usable project modes — cannot benchmark');
+  process.exit(1);
+}
+console.error('✅  Warm-up done\n');
+
+globalThis.gc?.();
+
+// ---------------------------------------------------------------------------
+// Register benchmarks
+// ---------------------------------------------------------------------------
+
+const PARSES_PER_ITER = 20;
+const TYPED_PER_ITER = 8;
+
+function makeRoundRobin(step) {
+  let cursor = 0;
+  return () => {
+    const files = [];
+    for (let i = 0; i < step; i++) {
+      files.push(GTS_FILES[cursor]);
+      cursor = (cursor + 1) % GTS_FILES.length;
+    }
+    return files;
+  };
+}
+
+for (const mode of MODES) {
+  const scenarios = [
+    {
+      name: `${mode.key} warm parse x${PARSES_PER_ITER}`,
+      makeFn: (parse, options) => {
+        const nextFiles = makeRoundRobin(PARSES_PER_ITER);
+        return () => {
+          for (const filePath of nextFiles()) doNotOptimize(parseFile(parse, options, filePath));
+        };
+      },
+    },
+    {
+      name: `${mode.key} parse+typed x${TYPED_PER_ITER}`,
+      makeFn: (parse, options) => {
+        const nextFiles = makeRoundRobin(TYPED_PER_ITER);
+        return () => {
+          for (const filePath of nextFiles()) doNotOptimize(typedQueries(parse, options, filePath));
+        };
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    globalThis.gc?.();
+    if (control) {
+      boxplot(() => {
+        summary(() => {
+          bench(
+            `${scenario.name} (control)`,
+            scenario.makeFn(control.parseForESLint, mode.controlOptions ?? mode.options)
+          );
+          bench(
+            `${scenario.name} (experiment)`,
+            scenario.makeFn(experiment.parseForESLint, mode.options)
+          );
+        });
+      });
+    } else {
+      bench(scenario.name, scenario.makeFn(experiment.parseForESLint, mode.options));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+const result = await run({ colors: false, throw: true });
+
+const jsonPath = process.env.BENCH_JSON_OUTPUT;
+if (jsonPath) {
+  const benchmarks = result.benchmarks.map((trial) => ({
+    alias: trial.alias,
+    runs: trial.runs.map((r) => ({
+      name: r.name,
+      args: r.args,
+      error: r.error ? { message: r.error.message || String(r.error) } : undefined,
+      stats: r.stats
+        ? {
+            avg: r.stats.avg,
+            min: r.stats.min,
+            max: r.stats.max,
+            p50: r.stats.p50,
+            p75: r.stats.p75,
+            p99: r.stats.p99,
+            samples: r.stats.samples,
+          }
+        : undefined,
+    })),
+  }));
+
+  writeFileSync(jsonPath, JSON.stringify({ context: result.context, benchmarks }, null, 2));
+}


### PR DESCRIPTION
Extracted from #235 so the benchmark infrastructure can be reviewed and land independently of the fix.

## What

The existing `tests/parser.bench.mjs` parses without `project`/`projectService` options, so it never invokes `patchTs`/`syncMtsGtsSourceFiles` — the type-aware machinery is invisible to it (its deltas on #235 read as pure noise: outliers flipped sign between CI and two local runs).

This adds `tests/project.bench.mjs`, which measures the type-aware path:

- generates a synthetic project into a temp dir — N `.gts` components (default 200, `BENCH_PROJECT_FILES` to override) importing each other extensionless, plus supporting `.ts` modules — so the program contains the virtual-twin SourceFiles the parser creates for real projects;
- builds the TS program during warm-up, then benchmarks **warm per-file parses** and **typed-rule-style checker queries** (`getTypeAtLocation` on every identifier, like `no-unnecessary-type-assertion` does);
- runs both `project` and `projectService` modes, feature-detecting the `projectService` spelling across typescript-eslint majors and dropping modes that can't hold `.gts` files in-project (v7's experimental service caps default-project files at 8);
- supports the same `--control-dir` protocol as `parser.bench.mjs` for head-to-head comparison, and the same `BENCH_JSON_OUTPUT` results format.

## Wiring

- `scripts/bench-compare.mjs` gains a `--bench <script>` flag (default unchanged: `tests/parser.bench.mjs`).
- New package scripts: `bench:project` (standalone) and `bench:project:compare` (vs `main`).
- `scripts/format-bench-comment.mjs` now renders one section per bench via repeated `--section <title> <output> <json>` triples; with no `--section` args it falls back to the original single-section `BENCH_OUTPUT_FILE`/`BENCH_JSON_OUTPUT` env interface, byte-identical output.
- The Benchmark Comparison workflow runs both benches and posts both tables in the single marker-managed PR comment (`### Parse` / `### Project mode (type-aware)`).

## Verified

- Formatter: two-section rendering, env fallback, and missing-file placeholder all exercised locally.
- The full pipeline already ran on CI from #235 before extraction ([run](https://github.com/ember-tooling/ember-eslint-parser/actions/runs/28760258845)): the project bench detected #235's improvement at **−34.9%** warm parse on a hosted runner while the parse suite stayed flat — exactly the sensitivity split it's meant to provide. On this PR (no parser changes) both sections should read ~0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)