### PR TITLE
Don't crash type-aware linting when the project's tsbuildinfo doesn't exist yet

### DIFF
--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -36,8 +36,18 @@ try {
       readFile(fname) {
         let fileName = fname;
         let content = '';
-        if (fileName.endsWith('tsconfig.tsbuildinfo')) {
-          return content;
+        if (fileName.endsWith('.tsbuildinfo')) {
+          // Incremental build state is optional: return it when present, but
+          // report a missing file as absent instead of throwing. The watch
+          // program reads `tsBuildInfoFile` without a fileExists probe
+          // (readBuilderProgram -> host.readFile), so a fresh/cleaned project
+          // with a custom buildinfo path (e.g. "declarations/.tsbuildinfo")
+          // would otherwise abort linting with a Parsing error: ENOENT.
+          try {
+            return fs.readFileSync(fileName).toString();
+          } catch {
+            return content;
+          }
         }
 
         try {

--- a/src/parser/ts-patch.js
+++ b/src/parser/ts-patch.js
@@ -37,17 +37,15 @@ try {
         let fileName = fname;
         let content = '';
         if (fileName.endsWith('.tsbuildinfo')) {
-          // Incremental build state is optional: return it when present, but
-          // report a missing file as absent instead of throwing. The watch
-          // program reads `tsBuildInfoFile` without a fileExists probe
-          // (readBuilderProgram -> host.readFile), so a fresh/cleaned project
-          // with a custom buildinfo path (e.g. "declarations/.tsbuildinfo")
-          // would otherwise abort linting with a Parsing error: ENOENT.
-          try {
-            return fs.readFileSync(fileName).toString();
-          } catch {
-            return content;
-          }
+          // Incremental build state is optional and never a .gts/.gjs file, so
+          // delegate to the real host: it returns the content when present and
+          // reports a missing file as absent (undefined) instead of throwing.
+          // The watch program reads `tsBuildInfoFile` without a fileExists
+          // probe (readBuilderProgram -> host.readFile), so a fresh/cleaned
+          // project with a custom buildinfo path (e.g.
+          // "declarations/.tsbuildinfo") would otherwise abort linting of
+          // every file with a Parsing error: ENOENT.
+          return sys.readFile(fileName);
         }
 
         try {

--- a/tests/ts-patch.test.js
+++ b/tests/ts-patch.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { patchTs } from '../src/parser/ts-patch.js';
+
+// Resolve the same typescript instance ts-patch patches (the one
+// @typescript-eslint/parser depends on), so we observe the patched ts.sys.
+const require = createRequire(import.meta.url);
+const parserPath = require.resolve('@typescript-eslint/parser');
+const ts = require(require.resolve('typescript', { paths: [parserPath] }));
+
+// Incremental build state is optional input: when `tsBuildInfoFile` points at
+// a file that has not been produced yet (fresh checkout, cleaned repo), the
+// watch program used for type-aware linting reads it WITHOUT a fileExists
+// probe (readBuilderProgram -> host.readFile). ts.sys.readFile's contract is
+// to report a missing file as absent, not to throw — a throw here aborts
+// linting of every file in the project with
+// `Parsing error: ENOENT ... <project>/declarations/.tsbuildinfo`.
+describe('patched ts.sys.readFile — .tsbuildinfo handling', () => {
+	patchTs();
+
+	it('treats a missing custom-named .tsbuildinfo as absent instead of throwing', () => {
+		// e.g. { "tsBuildInfoFile": "declarations/.tsbuildinfo" } — only the
+		// default `tsconfig.tsbuildinfo` name was guarded before.
+		const missing = path.join(os.tmpdir(), 'ee-parser-no-such-dir', 'declarations', '.tsbuildinfo');
+
+		expect(() => ts.sys.readFile(missing)).not.toThrow();
+		expect(ts.sys.readFile(missing)).toBe('');
+	});
+
+	it('returns the real content when the .tsbuildinfo exists', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ee-parser-buildinfo-'));
+		const buildInfo = path.join(dir, 'custom.tsbuildinfo');
+		fs.writeFileSync(buildInfo, '{"version":"5.9.3"}');
+
+		try {
+			expect(ts.sys.readFile(buildInfo)).toBe('{"version":"5.9.3"}');
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/ts-patch.test.js
+++ b/tests/ts-patch.test.js
@@ -20,26 +20,26 @@ const ts = require(require.resolve('typescript', { paths: [parserPath] }));
 // linting of every file in the project with
 // `Parsing error: ENOENT ... <project>/declarations/.tsbuildinfo`.
 describe('patched ts.sys.readFile — .tsbuildinfo handling', () => {
-	patchTs();
+  patchTs();
 
-	it('treats a missing custom-named .tsbuildinfo as absent instead of throwing', () => {
-		// e.g. { "tsBuildInfoFile": "declarations/.tsbuildinfo" } — only the
-		// default `tsconfig.tsbuildinfo` name was guarded before.
-		const missing = path.join(os.tmpdir(), 'ee-parser-no-such-dir', 'declarations', '.tsbuildinfo');
+  it('treats a missing custom-named .tsbuildinfo as absent instead of throwing', () => {
+    // e.g. { "tsBuildInfoFile": "declarations/.tsbuildinfo" } — only the
+    // default `tsconfig.tsbuildinfo` name was guarded before.
+    const missing = path.join(os.tmpdir(), 'ee-parser-no-such-dir', 'declarations', '.tsbuildinfo');
 
-		expect(() => ts.sys.readFile(missing)).not.toThrow();
-		expect(ts.sys.readFile(missing)).toBe('');
-	});
+    expect(() => ts.sys.readFile(missing)).not.toThrow();
+    expect(ts.sys.readFile(missing)).toBeUndefined();
+  });
 
-	it('returns the real content when the .tsbuildinfo exists', () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ee-parser-buildinfo-'));
-		const buildInfo = path.join(dir, 'custom.tsbuildinfo');
-		fs.writeFileSync(buildInfo, '{"version":"5.9.3"}');
+  it('returns the real content when the .tsbuildinfo exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ee-parser-buildinfo-'));
+    const buildInfo = path.join(dir, 'custom.tsbuildinfo');
+    fs.writeFileSync(buildInfo, '{"version":"5.9.3"}');
 
-		try {
-			expect(ts.sys.readFile(buildInfo)).toBe('{"version":"5.9.3"}');
-		} finally {
-			fs.rmSync(dir, { recursive: true, force: true });
-		}
-	});
+    try {
+      expect(ts.sys.readFile(buildInfo)).toBe('{"version":"5.9.3"}');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Running eslint with type-aware rules on a project whose tsconfig sets a custom `tsBuildInfoFile` (e.g. `"tsBuildInfoFile": "declarations/.tsbuildinfo"`) blows up on a fresh checkout / after cleaning build output:

> Parsing error: ENOENT: no such file or directory, open '.../declarations/.tsbuildinfo'

...for every file in the project.

The patched `ts.sys.readFile` already guards the *default* buildinfo name (`tsconfig.tsbuildinfo` → returns `''`), but any other name falls through to the gts/gjs rename fallback, matches neither, and the second `readFileSync` throws. The watch program (`readBuilderProgram`) reads the buildinfo without a `fileExists` probe, so `readFile` has to report a missing file as absent (that's `ts.sys.readFile`'s contract) rather than throw.

Fix: buildinfo is never a .gts/.gjs file, so the patched readFile just delegates any `.tsbuildinfo` path to the unpatched host readFile — content when present, `undefined` when missing. (This also means an *existing* default-named buildinfo is now actually read instead of discarded.)

Test covers both cases; the missing-file case fails on main with the exact ENOENT above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)